### PR TITLE
refactor: convert enums to string literals

### DIFF
--- a/src/containers/ImportWizard/ImportLocalFile/ImportLocalFile.tsx
+++ b/src/containers/ImportWizard/ImportLocalFile/ImportLocalFile.tsx
@@ -11,7 +11,6 @@ import { Hide, Show } from 'baseui/icon';
 import {
   EdgeListCsv,
   ImportFormat,
-  ImportType,
   JsonImport,
   NodeEdgeCsv,
   NodeEdgeDataType,
@@ -100,13 +99,13 @@ const ImportLocalFile = () => {
         const selectedDataType: string = watchDataType[0].id;
         const [fileExtension]: string[] = fileExts;
 
-        if (fileExtension === 'json' && selectedDataType === ImportType.JSON) {
+        if (fileExtension === 'json' && selectedDataType === 'json') {
           const jsonFileContents: JsonImport[] = fileContents.map(
             (content: string) => {
               const jsonGraphList: Graph.GraphList = JSON.parse(content);
               return {
                 data: jsonGraphList,
-                type: ImportType.JSON,
+                type: 'json',
               };
             },
           );
@@ -116,16 +115,13 @@ const ImportLocalFile = () => {
           return;
         }
 
-        if (
-          fileExtension === 'csv' &&
-          selectedDataType === ImportType.EDGE_LIST_CSV
-        ) {
+        if (fileExtension === 'csv' && selectedDataType === 'edgeListCsv') {
           const csvFileContents: EdgeListCsv[] = fileContents.map(
             (file: string) => {
               const cleanedFile: string = cleanInput(file);
               return {
                 data: cleanedFile,
-                type: ImportType.EDGE_LIST_CSV,
+                type: 'edgeListCsv',
               };
             },
           );
@@ -153,7 +149,7 @@ const ImportLocalFile = () => {
                 nodeData,
                 edgeData,
               },
-              type: ImportType.NODE_EDGE_CSV,
+              type: 'nodeEdgeCsv',
             };
 
             singleFileRef.current = nodeEdgeContent;
@@ -169,7 +165,7 @@ const ImportLocalFile = () => {
             const edgeData: string = cleanInput(fileContents[0] as string);
             const nodeEdgeContent: NodeEdgeCsv = {
               data: { nodeData, edgeData } as NodeEdgeDataType,
-              type: ImportType.NODE_EDGE_CSV,
+              type: 'nodeEdgeCsv',
             };
 
             singleFileRef.current = nodeEdgeContent;
@@ -208,15 +204,15 @@ const ImportLocalFile = () => {
       .map((k) => delete accessors[k]);
 
     const selectedDataType: string = watchDataType[0].id;
-    if (selectedDataType === ImportType.NODE_EDGE_CSV) {
+    if (selectedDataType === 'nodeEdgeCsv') {
       dispatch(importNodeEdgeData(singleFileRef.current, accessors));
     }
 
-    if (selectedDataType === ImportType.EDGE_LIST_CSV) {
+    if (selectedDataType === 'edgeListCsv') {
       dispatch(importEdgeListData(batchFileRef.current, accessors));
     }
 
-    if (selectedDataType === ImportType.JSON) {
+    if (selectedDataType === 'json') {
       dispatch(importJsonData(batchFileRef.current, accessors));
     }
 

--- a/src/containers/ImportWizard/ImportSampleData/ImportSampleData.tsx
+++ b/src/containers/ImportWizard/ImportSampleData/ImportSampleData.tsx
@@ -8,7 +8,7 @@ import * as Graph from '../../Graph/types';
 import * as DATA from '../../../constants/sample-data';
 import { FlushedGrid } from '../../../components/ui';
 import { closeModal, changeLayout } from '../../../redux';
-import { ImportType, JsonImport } from '../../../processors/import-data';
+import { JsonImport } from '../../../processors/import-data';
 import { importSingleJsonData } from '../../../redux/add-data-thunk';
 
 export enum SampleData {
@@ -26,7 +26,7 @@ export type SampleDataItem = {
   description: string;
   key: SampleData;
   src: string;
-  type: ImportType.JSON | ImportType.EDGE_LIST_CSV | ImportType.NODE_EDGE_CSV;
+  type: 'json' | 'edgeListCsv' | 'nodeEdgeCsv';
 };
 
 const sampleData: SampleDataItem[] = [
@@ -35,7 +35,7 @@ const sampleData: SampleDataItem[] = [
     title: 'Random Graph',
     description: 'A small random dataset to get started.',
     key: SampleData.RANDOM_GRAPH,
-    type: ImportType.JSON,
+    type: 'json',
     src:
       'https://storage.googleapis.com/cylynx-landing-content/random-data.png',
   },
@@ -45,7 +45,7 @@ const sampleData: SampleDataItem[] = [
     description:
       'Try displaying the data as a circle using one of the layout options.',
     key: SampleData.CIRCLE_GRAPH,
-    type: ImportType.JSON,
+    type: 'json',
     src:
       'https://storage.googleapis.com/cylynx-landing-content/circle-data.png',
   },
@@ -54,7 +54,7 @@ const sampleData: SampleDataItem[] = [
     title: 'Random + Circle',
     description: 'Import multiple data as in this example.',
     key: SampleData.SIMPLE_GRAPH,
-    type: ImportType.JSON,
+    type: 'json',
     src:
       'https://storage.googleapis.com/cylynx-landing-content/circle-random-data.png',
   },
@@ -63,7 +63,7 @@ const sampleData: SampleDataItem[] = [
     title: 'Les Misérables',
     description:
       'Character co-occurence in Les Misérables. Try coloring the grouping and displaying the data using a force-directed plot.',
-    type: ImportType.JSON,
+    type: 'json',
     key: SampleData.MISERABLE,
     src:
       'https://storage.googleapis.com/cylynx-landing-content/miserables-data.png',
@@ -73,7 +73,7 @@ const sampleData: SampleDataItem[] = [
     title: 'Authorship',
     description:
       'Co-authorship network of scientists working on network theory. 1.5k nodes and 2.7k edges.',
-    type: ImportType.JSON,
+    type: 'json',
     key: SampleData.NETWORK,
     src:
       'https://storage.googleapis.com/cylynx-landing-content/network-data.png',
@@ -83,7 +83,7 @@ const sampleData: SampleDataItem[] = [
     title: 'American Airlines',
     description:
       'Aggregated arrival and departure flights laid out as a U.S. map.',
-    type: ImportType.JSON,
+    type: 'json',
     key: SampleData.AA,
     src: 'https://storage.googleapis.com/cylynx-landing-content/aa-data.png',
   },
@@ -125,7 +125,7 @@ const StyledItem = ({ item }: { item: SampleDataItem }) => {
     }
 
     Promise.resolve(item.data()).then((d: void) => {
-      const sampleDataset: JsonImport = { data: d, type: ImportType.JSON };
+      const sampleDataset: JsonImport = { data: d, type: 'json' };
       dispatch(importSingleJsonData(sampleDataset, defaultAccessors));
     });
   };

--- a/src/processors/import-data.ts
+++ b/src/processors/import-data.ts
@@ -13,12 +13,6 @@ import { GraphData, GraphList, Accessors } from '../containers/Graph';
 
 export type ImportFormat = JsonImport | EdgeListCsv | NodeEdgeCsv;
 
-export enum ImportType {
-  JSON = 'json',
-  EDGE_LIST_CSV = 'edgeListCsv',
-  NODE_EDGE_CSV = 'nodeEdgeCsv',
-}
-
 export type NodeEdgeDataType = {
   nodeData: string;
   edgeData: string;
@@ -26,17 +20,17 @@ export type NodeEdgeDataType = {
 
 export type JsonImport = {
   data: GraphData | GraphList | void;
-  type: ImportType.JSON;
+  type: 'json';
 };
 
 export type EdgeListCsv = {
   data: string;
-  type: ImportType.EDGE_LIST_CSV;
+  type: 'edgeListCsv';
 };
 
 export type NodeEdgeCsv = {
   data: NodeEdgeDataType;
-  type: ImportType.NODE_EDGE_CSV;
+  type: 'nodeEdgeCsv';
 };
 
 export const OPTIONS = {

--- a/src/redux/add-data-thunk.test.js
+++ b/src/redux/add-data-thunk.test.js
@@ -13,7 +13,6 @@ import {
   importJson,
   importNodeEdgeCsv,
   importEdgeListCsv,
-  ImportType,
 } from '../processors/import-data';
 import { fetchBegin, fetchDone } from './ui-slice';
 import { SimpleEdge } from '../constants/sample-data';
@@ -42,7 +41,7 @@ describe('add-data-thunk.test.js', () => {
         key: 123,
       },
     },
-    type: ImportType.JSON,
+    type: 'json',
   };
   const jsonDataTwo = {
     data: {
@@ -52,7 +51,7 @@ describe('add-data-thunk.test.js', () => {
         key: 234,
       },
     },
-    type: ImportType.JSON,
+    type: 'json',
   };
 
   describe('importJsonData', () => {
@@ -108,7 +107,7 @@ describe('add-data-thunk.test.js', () => {
           key: 123,
         },
       },
-      type: ImportType.NODE_EDGE_CSV,
+      type: 'nodeEdgeCsv',
     };
 
     it('should receive importData as object and process graph responses accurately', async () => {
@@ -151,12 +150,12 @@ describe('add-data-thunk.test.js', () => {
     const firstEdgeListCsv = {
       data:
         'id,relation,source,target\ntxn1,works,jason,cylynx\ntxn3,abc,cylynx,timothy\ntxn4,says hi to,swan,cylynx',
-      type: ImportType.EDGE_LIST_CSV,
+      type: 'edgeListCsv',
     };
 
     const secondEdgeListCsv = {
       data: 'id,source,target\n123,x,y\n456,y,z\n789,z,x',
-      type: ImportType.EDGE_LIST_CSV,
+      type: 'edgeListCsv',
     };
 
     it('should receive importData as array and process graph responses accurately', async () => {
@@ -207,7 +206,7 @@ describe('add-data-thunk.test.js', () => {
     it('should receive importData as object and process graph accurately', async () => {
       // input
       const data = SimpleEdge();
-      const importData = { data, type: ImportType.JSON };
+      const importData = { data, type: 'json' };
 
       // processes
       const processedJsonData = await importJson(data, initialState.accessors);
@@ -230,7 +229,7 @@ describe('add-data-thunk.test.js', () => {
 
     it('should throw error if importData parameter is an array', async () => {
       const data = SimpleEdge();
-      const importData = { data, type: ImportType.JSON };
+      const importData = { data, type: 'json' };
 
       await expect(importSingleJsonData([importData])).toThrow(Error);
     });


### PR DESCRIPTION
## Summary 

 1. Convert `enum` to string literals 
 2. Refactor types and functions in `ImportLocalFile.tsx`, `ImportSampleData.tsx` and `import-data.ts` 
 3. Refactor unit test for `add-data-thunk.test.js` 

## Test Plan 
 1. Perform retest after modification is implemented. 
 2. Re-run unit test.

![Screenshot 2020-12-08 at 4 36 19 PM](https://user-images.githubusercontent.com/25884538/101459674-83314a80-3973-11eb-8cbe-a5acd8ccc607.png)

