### PR TITLE
Discrepancy Histogram Bar Colours

### DIFF
--- a/src/components/plots/HistogramPlot.tsx
+++ b/src/components/plots/HistogramPlot.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import { styled } from 'baseui';
 import { scaleLinear } from 'd3-scale';
 import { max } from 'd3-array';
+import { Theme } from 'baseui/theme';
 import { HistogramBin } from '../../utils/data-utils';
 import { PRIMARY_COLOR, DARK_GREY } from '../../constants/colors';
 
@@ -18,17 +19,22 @@ export type HistogramPlotProps = {
   brushComponent: any;
 };
 
+type StyledSvgType = {
+  $theme?: Theme;
+  width: number;
+  height: number;
+};
+
 const histogramStyle = {
   highlightW: 0.7,
   unHighlightedW: 0.6,
 };
 
-// @ts-ignore
-const StyledSvg = styled('svg', ({ $theme, width, height }) => ({
+const StyledSvg = styled('svg', ({ $theme, width, height }: StyledSvgType) => ({
   overflow: 'visible',
   width,
   height,
-  marginTop: '8px',
+  marginTop: $theme.sizing.scale300,
 }));
 
 const HistogramPlot = ({
@@ -63,7 +69,7 @@ const HistogramPlot = ({
     <StyledSvg width={width} height={height}>
       <g className='histogram-bars'>
         {histogram.map((bar: HistogramBin) => {
-          const median = (bar.x1 + bar.x0) / 2;
+          const median: number = (bar.x1 + bar.x0) / 2;
           const inRange: boolean = median <= value[1] && median >= value[0];
           const wRatio: number = inRange
             ? histogramStyle.highlightW


### PR DESCRIPTION
## Description 

1. Fix colour discrepancy in histogram bars with DateTime variable.
2. Fix colour discrepancy in histogram bars with Numeric variable.

## Additional Context 

Determine whether histogram bar is within the range of brush with **median ((x0 + x1) / 2)** instead of **lower boundary (x0)** and **upper boundary (x1)**

## Screenshot 

<img width="288" alt="Screenshot 2021-01-12 at 11 45 24 AM" src="https://user-images.githubusercontent.com/25884538/104266997-b95e6e80-54cb-11eb-8585-49e2782d0df4.png">

<img width="290" alt="Screenshot 2021-01-12 at 11 45 07 AM" src="https://user-images.githubusercontent.com/25884538/104267014-c2e7d680-54cb-11eb-950d-48ad4ec2e745.png">

