### PR TITLE
Prevent Screenshot and Export without Graph Data

### DIFF
--- a/src/containers/SidePanel/FilterPanel/FilterPanel.tsx
+++ b/src/containers/SidePanel/FilterPanel/FilterPanel.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Fragment, useMemo, MouseEvent, useCallback } from 'react';
 import { Block } from 'baseui/block';
 import { useSelector } from 'react-redux';
-import Header from '../Header/Header';
+import Header from '../Header';
 import FilterSelection from './FilterSelection';
 import AddFilterButton from './AddFilterButton';
 import useGraphFilter from './hooks/UseGraphFilter';

--- a/src/containers/SidePanel/Header/Header.tsx
+++ b/src/containers/SidePanel/Header/Header.tsx
@@ -3,7 +3,6 @@ import html2canvas from 'html2canvas';
 
 import { Block } from 'baseui/block';
 import { useDispatch, useSelector } from 'react-redux';
-import { AnyAction, Dispatch } from 'redux';
 import { GraphList } from '../../Graph';
 import { getGraphList, getUI, setName } from '../../../redux';
 import * as Icon from '../../../components/Icons';

--- a/src/containers/SidePanel/LayersPanel/LayersPanel.tsx
+++ b/src/containers/SidePanel/LayersPanel/LayersPanel.tsx
@@ -22,7 +22,7 @@ import {
   getGraphVisible,
   getGraphFlatten,
 } from '../../../redux';
-import Header from '../Header/Header';
+import Header from '../Header';
 
 const LayersPanel = () => {
   const dispatch = useDispatch();

--- a/src/containers/SidePanel/OptionsPanel/OptionsPanel.tsx
+++ b/src/containers/SidePanel/OptionsPanel/OptionsPanel.tsx
@@ -8,7 +8,7 @@ import {
   changeNodeStyle,
   changeEdgeStyle,
 } from '../../../redux';
-import Header from '../Header/Header';
+import Header from '../Header';
 import Accordion from '../../../components/Accordion';
 import {
   SimpleForm,


### PR DESCRIPTION
## Description 

1. Remove Screenshot button when no graph list is present.
2. Remove Export button when no graph list is present.

## Test Plan 
1. Construct cypress test case for branch coverage on `Header` component. 

## Motivation 

Display both Screenshot and Export button on the header when no graph data is present could potentially impact user experience with the following reasons:  

1. the buttons serve no purpose when no graph data is present. 
2. from a user-first perspective, display error notification when new user first learn the journey is not user friendly

## Screenshot 

<img width="1392" alt="Screenshot 2021-01-12 at 3 25 51 PM" src="https://user-images.githubusercontent.com/25884538/104282726-765fc380-54ea-11eb-9c0f-01e211a2f057.png">

Close #33 

