### PR TITLE
Tooltip does not render correct information

### DIFF
--- a/src/containers/Graph/Tooltip.tsx
+++ b/src/containers/Graph/Tooltip.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { styled } from 'baseui';
@@ -42,7 +43,7 @@ const Tooltip = ({ tooltip }: { tooltip: TooltipProps }) => {
             'data',
             edgeFields.filter((x) => !x.selected).map((x) => x.id),
           ),
-    [graphFlatten, edgeFields, nodeFields],
+    [graphFlatten, edgeFields, nodeFields, tooltip.id],
   );
 
   const contents = Object.entries(properties).map(([key, value]) => (


### PR DESCRIPTION
## Description 

- Fix tooltip does not render correct information. 

## Additional Context

Perform shallow comparison with `tooltip.id` instead of `tooltip` because the `id` is always unique in the node and edges. 
