### PR TITLE
Graphin Canvas Theming

### DIFF
--- a/src/constants/graph-styles.ts
+++ b/src/constants/graph-styles.ts
@@ -1,4 +1,5 @@
 import { EdgeStyle, NodeStyle } from '@antv/graphin';
+import { ThemeType } from '@antv/graphin/lib/consts';
 import { DEFAULT_EDGE_STYLE, DEFAULT_NODE_STYLE, GREY } from './graph-shapes';
 import { normalizeColor } from '../utils/style-utils';
 import { mapEdgePattern } from '../containers/Graph/shape/utils';
@@ -118,4 +119,22 @@ export const defaultEdgeStyle: { style: Partial<EdgeStyle> } = {
       cursor: 'pointer',
     },
   },
+};
+
+export const lightTheme: ThemeType = {
+  mode: 'light',
+  primaryColor: DEFAULT_NODE_STYLE.color,
+  nodeSize: DEFAULT_NODE_STYLE.size,
+  edgeSize: DEFAULT_EDGE_STYLE.width,
+  edgePrimaryColor: DEFAULT_EDGE_STYLE.color,
+  background: '#FFFFFF',
+};
+
+export const darkTheme: ThemeType = {
+  mode: 'dark',
+  primaryColor: DEFAULT_NODE_STYLE.color,
+  nodeSize: DEFAULT_NODE_STYLE.size,
+  edgeSize: DEFAULT_EDGE_STYLE.width,
+  edgePrimaryColor: '#f5f2f2',
+  background: '#000000',
 };

--- a/src/containers/Graph/Graph.tsx
+++ b/src/containers/Graph/Graph.tsx
@@ -13,6 +13,7 @@ import {
   defaultNodeStyle,
   defaultEdgeStyle,
   defaultEdgeStateStyle,
+  lightTheme,
 } from '../../constants/graph-styles';
 
 export type GraphProps = {
@@ -124,6 +125,7 @@ const Graph = React.forwardRef<Graphin, GraphProps>((props, ref) => {
       defaultEdge={defaultEdgeStyle}
       nodeStateStyles={defaultNodeStateStyle}
       edgeStateStyles={defaultEdgeStateStyle}
+      theme={lightTheme}
     />
   );
 });


### PR DESCRIPTION
## Description 

With the recent changes in [Build In Node and Shapes](https://github.com/cylynx/motif.gl/issues/55), it works well with build in Theme objects. 

- Sync our BaseUI theme with Graphin's Theme. 
- Construct light and dark theme object. 

## Improvement Required

1. The `defaultNode` and `defaultEdge` behaviour shall switch based on Theme's behaviour 
2. The background color of dark theme shall be further improve. 

## Additional Context 
 
![Screenshot 2021-01-29 at 5 11 20 PM](https://user-images.githubusercontent.com/25884538/106255443-032daf80-6255-11eb-8d3a-b3722f48c330.png)

As mentioned in the DingTalk, the theme switching feature is yet to be developed. Therefore, we can construct the data object for theme in order to prepare for the feature to be rollout or take some effort contribute to the Graphin library.

## Screenshot 

### Light Theme

<img width="1440" alt="light-theme" src="https://user-images.githubusercontent.com/25884538/106255166-a3cf9f80-6254-11eb-8801-48feab8dccd4.png">

### Dark Theme

<img width="1440" alt="dark-theme" src="https://user-images.githubusercontent.com/25884538/106255179-a92cea00-6254-11eb-88cd-1a5561128151.png">


