### PR TITLE
Strange behaviour filtering id, source and target fields

### DIFF
--- a/src/utils/data-utils/data-utils.ts
+++ b/src/utils/data-utils/data-utils.ts
@@ -112,8 +112,9 @@ export const getLinearDomain = (
     typeof valueAccessor === 'function'
       ? extent(data, valueAccessor)
       : extent(data);
+
   // @ts-ignore
-  return range.map((d, i) => (d === undefined ? i : d));
+  return range.map((d, i) => (d === undefined ? i : Number(d)));
 };
 
 /**


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Prevent `getLinearDomain` function return string values instead of numeric values.

## Detailed Description

The histogram fail to identify the range of numeric data with string range, results in the slider exceed out of containers. This bug also affects **Filter Panel**

## Technical Discussion

We will force the function to return numeric range as the histogram component only accept numeric range to prevent slider exceed the containers. 

## Test Plan

No test is applied in this conditions. 

## Does this PR introduce breaking change?

- No

