### PR TITLE
fix: jupyter widget styles

### DIFF
--- a/packages/motif/src/containers/SidePanel/SearchPanel/SearchPanel.tsx
+++ b/packages/motif/src/containers/SidePanel/SearchPanel/SearchPanel.tsx
@@ -28,7 +28,7 @@ const SearchPanel = () => {
     <Block
       position='absolute'
       height='100vh'
-      width='inherit'
+      width='92%'
       data-testid='search-panel'
     >
       <HeadingMedium marginTop='scale300' marginBottom='scale300'>

--- a/packages/pymotif/src/render-root.tsx
+++ b/packages/pymotif/src/render-root.tsx
@@ -9,6 +9,7 @@ import Motif, { MotifDarkTheme, MotifLightTheme } from '@cylynx/motif';
 import { Provider } from 'react-redux';
 import { EnhancedStore } from '@reduxjs/toolkit';
 import '@cylynx/motif/dist/style.css';
+import '../widget.css';
 
 const engine = new Styletron({ prefix: 'm_' });
 
@@ -33,6 +34,7 @@ function renderRoot(
             <Motif
               ref={graphRef}
               name='Motif'
+              primaryTheme={MotifLightTheme}
               secondaryTheme={MotifDarkTheme}
             />
           </Provider>

--- a/packages/pymotif/src/widget.ts
+++ b/packages/pymotif/src/widget.ts
@@ -9,9 +9,6 @@ import {
 
 import { MODULE_NAME, MODULE_VERSION } from './version';
 
-// Import the CSS
-import '../css/widget.css';
-
 export class ExampleModel extends DOMWidgetModel {
   defaults() {
     return {

--- a/packages/pymotif/widget.css
+++ b/packages/pymotif/widget.css
@@ -1,0 +1,4 @@
+/* To override jupyter lab ui box-sizing */
+*, *::before, *::after {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

Style fixes for jupyter widget

## Description

- Change search panel width from `inherit` to `92%` to prevent it from overflowing on jupyter labs
- Add a global css style sheet with `box-sizing: border-box;` to override jupyter lab preset

## Test Plan

Manually tested that both jupyter labs and notebooks look fine.

## Does this PR introduce breaking change?

No

## Closing Issue

close #146 
close #147 
