### PR TITLE
fix: typo in variable name

### DIFF
--- a/packages/motif-demo/src/containers/Neo4J/utils.ts
+++ b/packages/motif-demo/src/containers/Neo4J/utils.ts
@@ -81,11 +81,12 @@ export const toMotifFormat = (records: Record[]): GraphData => {
 
   // produce duplicate free nodes to display in table preview
   nodes = uniqBy(nodes, 'id');
-  edges = uniqBy(edge, 'id');
+  edges = uniqBy(edges, 'id');
 
   const graphData: GraphData = {
     nodes,
     edges,
   };
+  
   return graphData;
 };


### PR DESCRIPTION
## PR Type

Fix typo in neo4j utils in demo