### PR TITLE
Hotfix - Numeric Accessors

### DIFF
--- a/packages/motif/src/containers/ImportWizardModal/UploadFiles/ConfigureFields/AccessorFields.tsx
+++ b/packages/motif/src/containers/ImportWizardModal/UploadFiles/ConfigureFields/AccessorFields.tsx
@@ -84,34 +84,33 @@ const AccessorFields: FC<AccessorsFieldsProps> = ({
     [nodeIDOptions, edgeIDOptions, edgeFieldOptions],
   );
 
-  // useEffect(() => {
-  //   const setDefaultValue = (
-  //     options: Value,
-  //     name: keyof ConfigureFieldsForm,
-  //     value: string,
-  //   ) => {
-  //     const defaultOption = options.find(
-  //       (option: Option) => option.id === value,
-  //     );
+  useEffect(() => {
+    const setDefaultValue = (
+      options: Value,
+      name: keyof ConfigureFieldsForm,
+      value: string,
+    ) => {
+      const defaultOption = options.find(
+        (option: Option) => option.id === value,
+      );
 
-  //     if (defaultOption === undefined) {
-  //       const [firstOption] = options;
-  //       debugger;
-  //       setValue(name, firstOption.id as string);
-  //       return;
-  //     }
+      if (defaultOption === undefined) {
+        const [firstOption] = options;
+        setValue(name, firstOption.id as string);
+        return;
+      }
 
-  //     setValue(name, defaultOption.id as string);
-  //     return;
-  //   };
+      setValue(name, defaultOption.id as string);
+      return;
+    };
 
-  //   const { nodeID, edgeID, edgeSource, edgeTarget } =
-  //     getValues() as ConfigureFieldsForm;
-  //   setDefaultValue(nodeIDOptions, 'nodeID', nodeID);
-  //   setDefaultValue(edgeIDOptions, 'edgeID', edgeID);
-  //   setDefaultValue(edgeFieldOptions, 'edgeSource', edgeSource);
-  //   setDefaultValue(edgeFieldOptions, 'edgeTarget', edgeTarget);
-  // }, []);
+    const { nodeID, edgeID, edgeSource, edgeTarget } =
+      getValues() as ConfigureFieldsForm;
+    setDefaultValue(nodeIDOptions, 'nodeID', nodeID);
+    setDefaultValue(edgeIDOptions, 'edgeID', edgeID);
+    setDefaultValue(edgeFieldOptions, 'edgeSource', edgeSource);
+    setDefaultValue(edgeFieldOptions, 'edgeTarget', edgeTarget);
+  }, []);
 
   useEffect(() => {
     clearErrors();

--- a/packages/motif/src/containers/SidePanel/LayersPanel/sections/ImportLayers/ImportLayers.tsx
+++ b/packages/motif/src/containers/SidePanel/LayersPanel/sections/ImportLayers/ImportLayers.tsx
@@ -45,10 +45,10 @@ const ImportLayers = () => {
     dispatch(GraphSlices.deleteGraphList(index));
     resetSearchOptions();
 
-    if (nodeStyle.color.id === 'legend') {
+    if (nodeStyle.color?.id === 'legend') {
       switchToFixNodeColor();
     }
-    if (edgeStyle.color.id === 'legend') {
+    if (edgeStyle.color?.id === 'legend') {
       switchToFixEdgeColor();
     }
   };

--- a/packages/motif/src/redux/graph/processors/data.ts
+++ b/packages/motif/src/redux/graph/processors/data.ts
@@ -748,6 +748,10 @@ export const verifySourceAndTargetExistence = (
   const { nodeID, edgeID, edgeSource, edgeTarget } = accessors;
   const nodeIds: string[] = nodes.map((node: Node) => {
     const nodeIdProperty: string = get(node, nodeID, '');
+    if (typeof nodeIdProperty !== 'string') {
+      return nodeIdProperty;
+    }
+
     return nodeIdProperty.trim();
   });
   const uniqueNodeIds: string[] = uniq(nodeIds as string[]);

--- a/packages/motif/src/redux/graph/tests/constant.ts
+++ b/packages/motif/src/redux/graph/tests/constant.ts
@@ -13,3 +13,19 @@ export const whitespaceNodeEdge = {
     },
   ],
 };
+
+export const numericAccessorsNodeEdge = {
+  edgeCsv: [
+    {
+      fileName: 'numeric-accessors-1.csv',
+      content:
+        'id,relation,numeric_source,numeric_target\ntxn1,hello,1,2\ntxn2,works,2,3\ntxn3,abc,3,1\n',
+    },
+  ],
+  nodeCsv: [
+    {
+      fileName: 'numeric-accessors-2.csv',
+      content: 'custom_id,value,score\n1,20,80\n2,40,100\n3,60,123',
+    },
+  ],
+};

--- a/packages/motif/src/redux/graph/tests/thunk.test.tsx
+++ b/packages/motif/src/redux/graph/tests/thunk.test.tsx
@@ -53,7 +53,7 @@ import {
 import { getGraph } from '../selectors';
 import { resetState } from '../../import/fileUpload/slice';
 import { TFileContent } from '../../import/fileUpload';
-import { whitespaceNodeEdge } from './constant';
+import { numericAccessorsNodeEdge, whitespaceNodeEdge } from './constant';
 
 const mockStore = configureStore([thunk]);
 const getStore = (): RootState => {
@@ -163,11 +163,8 @@ describe('thunk.test.js', () => {
     const simpleGraphThree = {
       data: [
         {
-          nodes: [{ id: 1 }, { id: 2 }],
-          edges: [
-            { custom_source: 2, custom_target: 1 },
-            { custom_source: 1, custom_target: 2 },
-          ],
+          nodes: [{ custom_id: 1 }, { custom_id: 2 }],
+          edges: [{ id: 'custom-edge', custom_source: 2, custom_target: 1 }],
           metadata: {
             key: 234,
           },
@@ -175,7 +172,11 @@ describe('thunk.test.js', () => {
       ],
     };
 
-    const store = mockStore(getStore());
+    let store;
+
+    beforeEach(() => {
+      store = mockStore(getStore());
+    });
 
     afterEach(() => {
       store.clearActions();
@@ -183,10 +184,10 @@ describe('thunk.test.js', () => {
 
     it('should process custom accessors with numeric values accurately', async (done) => {
       const importDataArr = [simpleGraphThree];
-      const groupEdgeToggle = true;
+      const groupEdgeToggle = false;
 
       const customAccessors: Accessors = {
-        nodeID: 'id',
+        nodeID: 'custom_id',
         edgeID: 'id',
         edgeSource: 'custom_source',
         edgeTarget: 'custom_target',
@@ -194,7 +195,7 @@ describe('thunk.test.js', () => {
 
       // processes
       const batchDataPromises = importDataArr.map((graphData: ImportFormat) => {
-        const { data } = graphData as JsonImport;
+        const { data } = graphData;
         return importJson(data, customAccessors, groupEdgeToggle);
       });
 
@@ -202,7 +203,7 @@ describe('thunk.test.js', () => {
       const [graphData] = flatten(graphDataArr);
 
       // group edge configuration arrangements
-      const groupEdgeConfig = { availability: true, toggle: groupEdgeToggle };
+      const groupEdgeConfig = { availability: false, toggle: groupEdgeToggle };
       Object.assign(graphData.metadata.groupEdges, groupEdgeConfig);
 
       const expectedActions = [
@@ -937,6 +938,68 @@ describe('thunk.test.js', () => {
         .dispatch(
           importNodeEdgeData(
             whitespaceNodeEdge,
+            groupEdgeToggle,
+            accessors,
+            metadataKey,
+          ),
+        )
+        .then(() => {
+          setTimeout(() => {
+            expect(store.getActions()).toEqual(expectedActions);
+            done();
+          }, 300);
+        });
+    });
+
+    it('should process numeric custom nodeID, edgeSource and edgeTarget successfully', async (done) => {
+      const store = mockStore(getStore());
+      const { nodeCsv, edgeCsv } = numericAccessorsNodeEdge;
+      const accessors = {
+        nodeID: 'custom_id',
+        edgeID: 'id',
+        edgeSource: 'numeric_source',
+        edgeTarget: 'numeric_target',
+      };
+
+      const metadataKey = '123';
+      const groupEdgeToggle = false;
+
+      const nodeCsvs: string[] = nodeCsv.map(
+        (nodeCsv: TFileContent) => nodeCsv.content as string,
+      );
+      const edgeCsvs: string[] = edgeCsv.map(
+        (edgeCsv: TFileContent) => edgeCsv.content as string,
+      );
+
+      const data = await importNodeEdgeCsv(
+        nodeCsvs,
+        edgeCsvs,
+        accessors,
+        groupEdgeToggle,
+        metadataKey,
+      );
+
+      // group edge configurations
+      const groupEdgeConfig = { toggle: groupEdgeToggle, availability: true };
+      Object.assign(data.metadata.groupEdges, groupEdgeConfig);
+
+      const expectedActions = [
+        fetchBegin(),
+        addQuery(data),
+        processGraphResponse({
+          data,
+          accessors,
+        }),
+        updateToast('toast-0'),
+        resetState(),
+        fetchDone(),
+        closeModal(),
+      ];
+
+      return store
+        .dispatch(
+          importNodeEdgeData(
+            numericAccessorsNodeEdge,
             groupEdgeToggle,
             accessors,
             metadataKey,

--- a/packages/motif/src/redux/graph/thunk.ts
+++ b/packages/motif/src/redux/graph/thunk.ts
@@ -262,23 +262,22 @@ export const importNodeEdgeData =
       metadataKey,
     );
 
-    return newData
-      .then((graphData: GraphData) => {
-        dispatch(UISlices.fetchBegin());
+    return newData.then((graphData: GraphData) => {
+      dispatch(UISlices.fetchBegin());
 
-        setTimeout(() => {
-          processResponse(dispatch, mainAccessors, graphData);
-          showImportDataToast(dispatch, filterOptions);
-          dispatch(FileUploadSlices.resetState());
-          dispatch(UISlices.fetchDone());
-          dispatch(UISlices.closeModal());
-        }, 200);
-      })
-      .catch((err: Error) => {
-        const { message } = err;
-        dispatch(UIThunks.show(message, 'negative'));
+      setTimeout(() => {
+        processResponse(dispatch, mainAccessors, graphData);
+        showImportDataToast(dispatch, filterOptions);
+        dispatch(FileUploadSlices.resetState());
         dispatch(UISlices.fetchDone());
-      });
+        dispatch(UISlices.closeModal());
+      }, 200);
+    });
+    // .catch((err: Error) => {
+    //   const { message } = err;
+    //   dispatch(UIThunks.show(message, 'negative'));
+    //   dispatch(UISlices.fetchDone());
+    // });
   };
 
 /**

--- a/packages/motif/src/redux/graph/thunk.ts
+++ b/packages/motif/src/redux/graph/thunk.ts
@@ -160,7 +160,7 @@ export const importJsonData =
   (
     importData: JsonImport[],
     groupEdges = true,
-    importAccessors: ImportAccessors = null,
+    importAccessors: Partial<ImportAccessors> = {},
     overwriteStyles = false,
   ) =>
   (dispatch: any, getState: any) => {
@@ -168,8 +168,13 @@ export const importJsonData =
       throw new Error('Provided import data is not an array');
     }
 
+    const isCustomAccessorEmpty = isEmpty(importAccessors);
+
     const { accessors: mainAccessors } = getGraph(getState());
-    const accessors = { ...mainAccessors, ...importAccessors };
+    const accessors = isCustomAccessorEmpty
+      ? mainAccessors
+      : (importAccessors as ImportAccessors);
+
     const filterOptions: FilterOptions = getFilterOptions(getState());
     let isDataPossessStyle = false;
     let styleOptions: StyleOptions = getStyleOptions(getState());
@@ -206,7 +211,7 @@ export const importJsonData =
             dispatch(updateStyleOption(styleOptions));
           }
 
-          processResponse(dispatch, mainAccessors, graphData);
+          processResponse(dispatch, accessors, graphData);
 
           showImportDataToast(dispatch, filterOptions);
           dispatch(FileUploadSlices.resetState());
@@ -226,7 +231,7 @@ export const importJsonData =
  *
  * @param {SingleFileForms} importData - attachment contains one or more node edge attachments
  * @param {boolean} groupEdges - group graph's edges
- * @param {ImportAccessors} importAccessors [importAccessors=null] - to customize node Id / edge Id / edge source or target
+ * @param {Partial<ImportAccessors>} importAccessors [importAccessors={}] - to customize node Id / edge Id / edge source or target
  * @param {number} metadataKey [metadataKey=null]
  * @return {Promise<GraphData>}
  */
@@ -234,7 +239,7 @@ export const importNodeEdgeData =
   (
     importData: SingleFileForms,
     groupEdges = true,
-    importAccessors: ImportAccessors = null,
+    importAccessors: Partial<ImportAccessors> = {},
     metadataKey: string = null,
   ) =>
   (dispatch: any, getState: any) => {
@@ -243,7 +248,9 @@ export const importNodeEdgeData =
     }
 
     const { accessors: mainAccessors } = getGraph(getState());
-    const accessors = { ...mainAccessors, ...importAccessors };
+    const accessors = isEmpty(importAccessors)
+      ? mainAccessors
+      : (importAccessors as ImportAccessors);
     const filterOptions: FilterOptions = getFilterOptions(getState());
 
     const { nodeCsv: nodeContents, edgeCsv: edgeContents } = importData;
@@ -267,7 +274,7 @@ export const importNodeEdgeData =
         dispatch(UISlices.fetchBegin());
 
         setTimeout(() => {
-          processResponse(dispatch, mainAccessors, graphData);
+          processResponse(dispatch, accessors, graphData);
           showImportDataToast(dispatch, filterOptions);
           dispatch(FileUploadSlices.resetState());
           dispatch(UISlices.fetchDone());
@@ -286,17 +293,20 @@ export const importNodeEdgeData =
  *
  * @param {JsonImport} importData
  * @param {boolean} groupEdges [groupEdges=true] - group graph's edges
- * @param {ImportAccessors} importAccessors [importAccessors=null] - to customize node Id / edge Id / edge source or target
+ * @param {Partial<ImportAccessors>} importAccessors [importAccessors={}] - to customize node Id / edge Id / edge source or target
  */
 export const importSampleData =
   (
     importData: JsonImport,
-    importAccessors: ImportAccessors = null,
+    importAccessors: Partial<ImportAccessors> = {},
     groupEdges = false,
   ) =>
   async (dispatch: any, getState: any): Promise<void> => {
     const { accessors: mainAccessors } = getGraph(getState());
-    const accessors = { ...mainAccessors, ...importAccessors };
+
+    const accessors = isEmpty(importAccessors)
+      ? mainAccessors
+      : (importAccessors as ImportAccessors);
     const filterOptions: FilterOptions = getFilterOptions(getState());
 
     const newData: Promise<GraphList> = importJson(
@@ -310,7 +320,7 @@ export const importSampleData =
         dispatch(UISlices.fetchBegin());
 
         setTimeout(() => {
-          processResponse(dispatch, mainAccessors, graphData);
+          processResponse(dispatch, accessors, graphData);
           showImportDataToast(dispatch, filterOptions);
           dispatch(FileUploadSlices.resetState());
           dispatch(UISlices.fetchDone());

--- a/packages/motif/src/redux/graph/thunk.ts
+++ b/packages/motif/src/redux/graph/thunk.ts
@@ -262,22 +262,23 @@ export const importNodeEdgeData =
       metadataKey,
     );
 
-    return newData.then((graphData: GraphData) => {
-      dispatch(UISlices.fetchBegin());
+    return newData
+      .then((graphData: GraphData) => {
+        dispatch(UISlices.fetchBegin());
 
-      setTimeout(() => {
-        processResponse(dispatch, mainAccessors, graphData);
-        showImportDataToast(dispatch, filterOptions);
-        dispatch(FileUploadSlices.resetState());
+        setTimeout(() => {
+          processResponse(dispatch, mainAccessors, graphData);
+          showImportDataToast(dispatch, filterOptions);
+          dispatch(FileUploadSlices.resetState());
+          dispatch(UISlices.fetchDone());
+          dispatch(UISlices.closeModal());
+        }, 200);
+      })
+      .catch((err: Error) => {
+        const { message } = err;
+        dispatch(UIThunks.show(message, 'negative'));
         dispatch(UISlices.fetchDone());
-        dispatch(UISlices.closeModal());
-      }, 200);
-    });
-    // .catch((err: Error) => {
-    //   const { message } = err;
-    //   dispatch(UIThunks.show(message, 'negative'));
-    //   dispatch(UISlices.fetchDone());
-    // });
+      });
   };
 
 /**


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

1. Fix `Configure Field` does not configure initial value properly on render, results in `source` and `target` selected as default even though the user interface are showing other accessors.
2. Unable to import when node styles are not legend.
3. Fix unable to import when accessors value are integer in JSON and Node Edge import. 

## Test Plan

1. Will include additional coverage on thunk to prevent this issue re-occurs.

## Does this PR introduce breaking change?

- No
