### PR TITLE
fix: zero value properties should be styled

### DIFF
--- a/packages/motif/src/utils/style-utils/style-edges.ts
+++ b/packages/motif/src/utils/style-utils/style-edges.ts
@@ -397,7 +397,8 @@ export const styleEdgeColor = (
   const variableProperty: string | unknown = get(edge, variable);
   const defaultEdgeColor = normalizeColor(EDGE_DEFAULT_COLOR);
 
-  if (variableProperty) {
+  // Exclude null or undefined
+  if (!(variableProperty == null)) {
     const edgeColor = normalizeColor(mapping[variableProperty as string]);
 
     Object.assign(edgeStyle, {

--- a/packages/motif/src/utils/style-utils/style-nodes.ts
+++ b/packages/motif/src/utils/style-utils/style-nodes.ts
@@ -272,7 +272,8 @@ export const styleNodeColor = (
   const variableProperty: string | unknown = get(node, variable);
   const grey = normalizeColor(GREY);
 
-  if (variableProperty) {
+  // Exclude null or undefined
+  if (!(variableProperty == null)) {
     const nodeColor = normalizeColor(mapping[variableProperty as string]);
 
     Object.assign(nodeStyle, {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

Bugfix

## Description

0 values are not colored by the legend as they are nullish and filtered out during the legend color mapping