### PR TITLE
Hotfix - Properties Overrides on Second Imports

### DIFF
--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -24,7 +24,10 @@ import {
   Selection,
   UpdateGroupEdgeIds,
 } from './types';
-import { DEFAULT_NODE_STYLE, EDGE_DEFAULT_COLOR } from '../../constants/graph-shapes';
+import {
+  DEFAULT_NODE_STYLE,
+  EDGE_DEFAULT_COLOR,
+} from '../../constants/graph-shapes';
 import { groupEdgesForImportation } from './processors/group-edges';
 import { combineProcessedData } from '../../utils/graph-utils/utils';
 

--- a/packages/motif/src/redux/graph/tests/constant.ts
+++ b/packages/motif/src/redux/graph/tests/constant.ts
@@ -29,3 +29,57 @@ export const numericAccessorsNodeEdge = {
     },
   ],
 };
+
+export const sampleJson1 = {
+  nodes: [
+    {
+      id: 'node-1',
+      node1: '1',
+    },
+    {
+      id: 'node-2',
+      node1: '2',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      source: 'node-1',
+      target: 'node-2',
+      edge1: '1',
+    },
+    {
+      id: 'edge-2',
+      source: 'node-2',
+      target: 'node-1',
+      edge1: '2',
+    },
+  ],
+};
+
+export const sampleJson2 = {
+  nodes: [
+    {
+      id: 'node-1',
+      node2: '1',
+    },
+    {
+      id: 'node-2',
+      node2: '2',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      source: 'node-1',
+      target: 'node-2',
+      edge2: '1',
+    },
+    {
+      id: 'edge-2',
+      source: 'node-2',
+      target: 'node-1',
+      edge2: '2',
+    },
+  ],
+};

--- a/packages/motif/src/utils/graph-utils/utils.test.ts
+++ b/packages/motif/src/utils/graph-utils/utils.test.ts
@@ -1,55 +1,92 @@
 import { Edge } from '../../redux/graph/types';
-import { getEdgeProperties } from './utils';
+import { getEdgeProperties, removeDuplicates } from './utils';
 
-describe('Graph Utilities', () => {
-  describe('getEdgeProperties', () => {
-    const sampleEdge: Edge = {
-      id: 'cat-dog',
-      source: 'cat',
-      target: 'dog',
-      true: true,
-      false: false,
-      number: 0,
-      object: {
-        string: '123123123',
-        object2: {
-          value: 1,
-        },
+describe('getEdgeProperties', () => {
+  const sampleEdge: Edge = {
+    id: 'cat-dog',
+    source: 'cat',
+    target: 'dog',
+    true: true,
+    false: false,
+    number: 0,
+    object: {
+      string: '123123123',
+      object2: {
+        value: 1,
       },
-    };
+    },
+  };
 
-    const kind = 'all';
-    let edgeProperties: Partial<Edge> = {};
-    beforeAll(() => {
-      edgeProperties = getEdgeProperties(sampleEdge, kind, []);
+  const kind = 'all';
+  let edgeProperties: Partial<Edge> = {};
+  beforeAll(() => {
+    edgeProperties = getEdgeProperties(sampleEdge, kind, []);
+  });
+
+  afterAll(() => {
+    edgeProperties = {};
+  });
+
+  it('should possess id, source and target', () => {
+    const { id, source, target } = edgeProperties as Edge;
+    expect(id).toEqual(sampleEdge.id);
+    expect(source).toEqual(sampleEdge.source);
+    expect(target).toEqual(sampleEdge.target);
+  });
+
+  it('should possess boolean properties without ignore false', () => {
+    expect(edgeProperties.true).toEqual(sampleEdge.true);
+    expect(edgeProperties.false).toEqual(sampleEdge.false);
+  });
+
+  it('should possess number value without ignore zero', () => {
+    const { number } = edgeProperties;
+    expect(number).toEqual(sampleEdge.number);
+  });
+
+  it('should remains nested object value', () => {
+    expect(edgeProperties['object.string']).toEqual(sampleEdge.object.string);
+    expect(edgeProperties['object.object2.value']).toEqual(
+      sampleEdge.object.object2.value,
+    );
+  });
+});
+describe('removeDuplicates', () => {
+  it('should remove duplicate item with specific identifer', () => {
+    const input = [{ id: 1 }, { id: 1 }];
+    const outcome = removeDuplicates(input, 'id');
+
+    expect(outcome.length).toEqual(1);
+  });
+
+  it('should merge attributes of the duplicate elements', () => {
+    const input = [
+      { id: '1', custom: 'node1' },
+      { id: '1', default: 'node2' },
+    ];
+
+    const outcome = removeDuplicates(input, 'id');
+
+    const [firstElement] = outcome;
+    expect(firstElement).toStrictEqual({
+      id: '1',
+      custom: 'node1',
+      default: 'node2',
     });
+  });
 
-    afterAll(() => {
-      edgeProperties = {};
-    });
+  it('should not merge attributes without duplicate identifier', () => {
+    const input = [
+      { id: '1', custom: 'node1' },
+      { id: '2', default: 'node2' },
+    ];
 
-    it('should possess id, source and target', () => {
-      const { id, source, target } = edgeProperties as Edge;
-      expect(id).toEqual(sampleEdge.id);
-      expect(source).toEqual(sampleEdge.source);
-      expect(target).toEqual(sampleEdge.target);
-    });
+    const outcome = removeDuplicates(input, 'id');
 
-    it('should possess boolean properties without ignore false', () => {
-      expect(edgeProperties.true).toEqual(sampleEdge.true);
-      expect(edgeProperties.false).toEqual(sampleEdge.false);
-    });
-
-    it('should possess number value without ignore zero', () => {
-      const { number } = edgeProperties;
-      expect(number).toEqual(sampleEdge.number);
-    });
-
-    it('should remains nested object value', () => {
-      expect(edgeProperties['object.string']).toEqual(sampleEdge.object.string);
-      expect(edgeProperties['object.object2.value']).toEqual(
-        sampleEdge.object.object2.value,
-      );
+    const [firstElement] = outcome;
+    expect(firstElement).toStrictEqual({
+      id: '1',
+      custom: 'node1',
     });
   });
 });

--- a/packages/motif/src/utils/graph-utils/utils.ts
+++ b/packages/motif/src/utils/graph-utils/utils.ts
@@ -660,6 +660,7 @@ export const combineProcessedData = (
       [...newData.nodes, ...oldData.nodes],
       'id',
     ) as Node[];
+
     modData.edges = removeDuplicates(
       [...newData.edges, ...oldData.edges],
       'id',
@@ -703,20 +704,34 @@ export const combineDataWithDuplicates = (
 
 /**
  * Remove duplicates from array by checking on prop
+ * - the attributes should be merged after remove the duplicates
+ *
  *
  * @param {(Node[] | Edge[] | Field[] | [])} myArr
- * @param {string} prop
  * @return {Node[] | Edge[] | Field[]}
  */
 export const removeDuplicates = (
-  myArr: Node[] | Edge[] | Field[] | [],
+  myArr: Node[] | Edge[] | Field[] | any[],
   prop: string,
 ): Node[] | Edge[] | Field[] => {
-  const seen = new Set();
-  const filteredArr = (myArr as any[]).filter((el) => {
-    const duplicate = seen.has(el[prop]);
-    seen.add(el[prop]);
-    return !duplicate;
-  });
+  const seen = {};
+
+  const filteredArr = myArr
+    .filter((el) => {
+      const duplicate = has(seen, [el[prop]]);
+      seen[el[prop]] = el;
+      return !duplicate;
+    })
+    .map((el) => {
+      const duplicate = has(seen, [el[prop]]);
+      if (!duplicate) return el;
+
+      const propAttributes = seen[el[prop]];
+      return {
+        ...el,
+        ...propAttributes,
+      };
+    });
+
   return filteredArr;
 };

--- a/packages/motif/src/utils/graph-utils/utils.ts
+++ b/packages/motif/src/utils/graph-utils/utils.ts
@@ -704,8 +704,9 @@ export const combineDataWithDuplicates = (
 
 /**
  * Remove duplicates from array by checking on prop
- * - the attributes should be merged after remove the duplicates
  *
+ * @see https://github.com/cylynx/motif.gl/issues/173
+ * - the attributes should be merged after remove the duplicates
  *
  * @param {(Node[] | Edge[] | Field[] | [])} myArr
  * @return {Node[] | Edge[] | Field[]}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

- The attributes of nodes and edges should be merged after remove the duplicates 


## Test Plan

Please check if your test fulfill the following requirements:

- Improve unit test coverage on `removeDuplicates` function. 

## Does this PR introduce breaking change?

- No



