### PR TITLE
Feature - Export Graph Positions 

### DIFF
--- a/packages/motif/src/containers/SidePanel/Header/Header.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/Header.tsx
@@ -3,12 +3,14 @@ import html2canvas from 'html2canvas';
 
 import { Block } from 'baseui/block';
 import { useDispatch, useSelector } from 'react-redux';
+import { setGraphListPosition } from '../../../utils/export-utils/export-utils';
 import { UISelectors, UISlices } from '../../../redux/ui';
 import {
   GraphSelectors,
   StyleOptions,
   TLoadFormat,
   GraphList,
+  GraphData,
 } from '../../../redux/graph';
 import * as Icon from '../../../components/Icons';
 import Editable from '../../../components/Editable';
@@ -18,6 +20,10 @@ const Header = () => {
   const name: string = useSelector((state) => UISelectors.getUI(state).name);
   const graphList: GraphList = useSelector((state) =>
     GraphSelectors.getGraphList(state),
+  );
+
+  const graphFlatten: GraphData = useSelector((state) =>
+    GraphSelectors.getGraphFlatten(state),
   );
 
   const styleOptions: StyleOptions = useSelector((state) =>
@@ -48,8 +54,9 @@ const Header = () => {
   }, [isCanvasHasGraph]);
 
   const exportJSON = (graphList: GraphList, styleOptions: StyleOptions) => {
+    const positionGraphList = setGraphListPosition(graphList, graphFlatten);
     const exportData: TLoadFormat = {
-      data: graphList,
+      data: positionGraphList,
       style: styleOptions,
     };
 
@@ -80,7 +87,7 @@ const Header = () => {
         onClick: () => exportJSON(graphList, styleOptions),
       },
     ],
-    [dispatch, exportPNG, exportJSON, graphList, styleOptions],
+    [dispatch, exportPNG, exportJSON, graphList, styleOptions, graphFlatten],
   );
 
   return useMemo(

--- a/packages/motif/src/utils/export-utils/export-utils.ts
+++ b/packages/motif/src/utils/export-utils/export-utils.ts
@@ -1,0 +1,47 @@
+import { has, cloneDeep } from 'lodash';
+import { GraphData, GraphList } from '../../redux/graph';
+
+export const setGraphListPosition = (
+  graphList: GraphList,
+  graphFlatten: GraphData,
+): GraphList => {
+  const { nodes } = graphFlatten;
+
+  const nodesWithPosition = nodes.filter((node) => {
+    return has(node, 'x') && has(node, 'y');
+  });
+
+  if (nodesWithPosition.length === 0) return graphList;
+
+  const nodePositionDict = nodesWithPosition.reduce((arr, node) => {
+    const { id, x, y } = node;
+    Object.assign(arr, {
+      [id]: { x, y },
+    });
+    return arr;
+  }, {});
+
+  const graphListWithPosition = graphList.map((graphData) => {
+    const { nodes } = graphData;
+
+    const attachedPositionNodes = nodes.map((node) => {
+      const { id } = node;
+
+      const nodeHasPosition = has(nodePositionDict, id);
+      if (!nodeHasPosition) return node;
+
+      const nodeCoordinate = nodePositionDict[id];
+      const { x, y } = nodeCoordinate;
+      return { ...node, x, y };
+    });
+
+    const modData = cloneDeep(graphData);
+    Object.assign(modData, {
+      nodes: attachedPositionNodes,
+    });
+
+    return modData;
+  });
+
+  return graphListWithPosition;
+};

--- a/packages/motif/src/utils/export-utils/index.ts
+++ b/packages/motif/src/utils/export-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './export-utils';

--- a/packages/motif/src/utils/export-utils/tests/constant.ts
+++ b/packages/motif/src/utils/export-utils/tests/constant.ts
@@ -1,0 +1,115 @@
+export const stateWithPosition = {
+  graphList: [
+    {
+      nodes: [{ id: 'node-1' }, { id: 'node-2' }],
+      edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2' }],
+    },
+    {
+      nodes: [{ id: 'node-3' }, { id: 'node-4' }],
+      edges: [{ id: 'edge-2', source: 'node-3', target: 'node-4' }],
+    },
+    {
+      nodes: [{ id: 'node-5' }, { id: 'node-6' }],
+      edges: [{ id: 'edge-3', source: 'node-5', target: 'node-6' }],
+    },
+  ],
+  graphFlatten: {
+    nodes: [
+      {
+        id: 'node-1',
+        x: 1,
+        y: 1,
+      },
+      {
+        id: 'node-2',
+        x: 2,
+        y: 2,
+      },
+      {
+        id: 'node-3',
+        x: 3,
+        y: 3,
+      },
+      {
+        id: 'node-4',
+        x: 4,
+        y: 4,
+      },
+      {
+        id: 'node-5',
+        x: 5,
+        y: 5,
+      },
+      {
+        id: 'node-6',
+        x: 6,
+        y: 6,
+      },
+    ],
+    edges: [
+      { id: 'edge-1', source: 'node-1', target: 'node-2' },
+      {
+        id: 'edge-2',
+        source: 'node-3',
+        target: 'node-4',
+      },
+      {
+        id: 'edge-3',
+        source: 'node-5',
+        target: 'node-6',
+      },
+    ],
+  },
+};
+
+export const stateWithoutPosition = {
+  graphList: [
+    {
+      nodes: [{ id: 'node-1' }, { id: 'node-2' }],
+      edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2' }],
+    },
+    {
+      nodes: [{ id: 'node-3' }, { id: 'node-4' }],
+      edges: [{ id: 'edge-2', source: 'node-3', target: 'node-4' }],
+    },
+    {
+      nodes: [{ id: 'node-5' }, { id: 'node-6' }],
+      edges: [{ id: 'edge-3', source: 'node-5', target: 'node-6' }],
+    },
+  ],
+  graphFlatten: {
+    nodes: [
+      {
+        id: 'node-1',
+      },
+      {
+        id: 'node-2',
+      },
+      {
+        id: 'node-3',
+      },
+      {
+        id: 'node-4',
+      },
+      {
+        id: 'node-5',
+      },
+      {
+        id: 'node-6',
+      },
+    ],
+    edges: [
+      { id: 'edge-1', source: 'node-1', target: 'node-2' },
+      {
+        id: 'edge-2',
+        source: 'node-3',
+        target: 'node-4',
+      },
+      {
+        id: 'edge-3',
+        source: 'node-5',
+        target: 'node-6',
+      },
+    ],
+  },
+};

--- a/packages/motif/src/utils/export-utils/tests/export-utils.test.ts
+++ b/packages/motif/src/utils/export-utils/tests/export-utils.test.ts
@@ -1,0 +1,44 @@
+import { setGraphListPosition } from '../export-utils';
+import { stateWithoutPosition, stateWithPosition } from './constant';
+
+describe('Export File Utilities', () => {
+  describe('setGraphListPosition', () => {
+    it('should attach the node position from graphFlatten to graphList', () => {
+      const { graphList, graphFlatten } = stateWithPosition;
+      const graphListWithPos = setGraphListPosition(graphList, graphFlatten);
+
+      const expectedGraphList = [
+        {
+          nodes: [
+            { id: 'node-1', x: 1, y: 1 },
+            { id: 'node-2', x: 2, y: 2 },
+          ],
+          edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2' }],
+        },
+        {
+          nodes: [
+            { id: 'node-3', x: 3, y: 3 },
+            { id: 'node-4', x: 4, y: 4 },
+          ],
+          edges: [{ id: 'edge-2', source: 'node-3', target: 'node-4' }],
+        },
+        {
+          nodes: [
+            { id: 'node-5', x: 5, y: 5 },
+            { id: 'node-6', x: 6, y: 6 },
+          ],
+          edges: [{ id: 'edge-3', source: 'node-5', target: 'node-6' }],
+        },
+      ];
+
+      expect(graphListWithPos).toEqual(expectedGraphList);
+    });
+  });
+
+  it('should return original graphList when graphFlatten no position', () => {
+    const { graphList, graphFlatten } = stateWithoutPosition;
+    const graphListWithPos = setGraphListPosition(graphList, graphFlatten);
+
+    expect(graphListWithPos).toEqual(graphList);
+  });
+});


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Features

## Description

- JSON export should save the last positioned graph layout.
- JSON import should loads the last position graph layout. If no position in layout is found, default layout is loaded. 

## Technical Discussion

- Using an object to store `graphFlatten` node position as lookup table, attach nodes with coordinate onto `graphList`.

## Test Plan

- Implement Jest unit test on the mentioned function. 

## Does this PR introduce breaking change?

- No data format changes. 

close #182 
