### PR TITLE
chore: update graphin to 2.1.0 and vite to 2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^10.0.3",
     "prettier": "^2.2.1",
+    "tslib": "^2.3.0",
     "typescript": "^4.2.4",
     "webpack": "4.42.0"
   },

--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "motif-demo",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "start": "vite --force",
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.2",
+    "@cylynx/motif": "^0.0.4",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",
@@ -27,7 +27,7 @@
     "@types/react": "^16.9.27",
     "@types/react-dom": "^16.9.7",
     "@vitejs/plugin-react-refresh": "^1.3.1",
-    "vite": "2.2.4"
+    "vite": "2.4.3"
   },
   "browserslist": {
     "production": [

--- a/packages/motif-demo/vite.build.config.ts
+++ b/packages/motif-demo/vite.build.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    keepNames: true,
+    esbuildOptions: {
+      keepNames: true,
+    },
   },
 });

--- a/packages/motif-demo/vite.config.js
+++ b/packages/motif-demo/vite.config.js
@@ -5,6 +5,8 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [reactRefresh()],
   optimizeDeps: {
-    keepNames: true,
+    esbuildOptions: {
+      keepNames: true,
+    },
   },
 });

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [
@@ -29,8 +29,8 @@
     "clean": "rimraf -rf ./dist"
   },
   "dependencies": {
-    "@antv/g6": "4.1.13",
-    "@cylynx/graphin": "2.0.20",
+    "@antv/g6": "4.3.2",
+    "@cylynx/graphin": "2.1.1",
     "@reduxjs/toolkit": "^1.5.0",
     "d3-array": "^2.12.1",
     "d3-axis": "^2.1.0",
@@ -113,7 +113,7 @@
     "ts-loader": "^8.0.15",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4",
-    "vite": "2.2.4",
+    "vite": "2.4.3",
     "webpack": "4.42.0",
     "workerloader-jest-transformer": "^0.0.2"
   },

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf -rf ./dist"
   },
   "dependencies": {
-    "@antv/g6": "4.3.2",
+    "@antv/g6": "4.3.4",
     "@cylynx/graphin": "2.1.1",
     "@reduxjs/toolkit": "^1.5.0",
     "d3-array": "^2.12.1",

--- a/packages/motif/src/containers/widgets/layer.tsx
+++ b/packages/motif/src/containers/widgets/layer.tsx
@@ -105,9 +105,13 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
 
   shouldComponentUpdate(
     nextProps: GraphLayerProps,
-    _: GraphLayerState,
+    nextState: GraphLayerState,
   ): boolean {
     if (this.props.isMainWidgetExpanded !== nextProps.isMainWidgetExpanded) {
+      return true;
+    }
+
+    if (this.state.left !== nextState.left) {
       return true;
     }
 

--- a/packages/motif/vite.dev.config.ts
+++ b/packages/motif/vite.dev.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   clearScreen: false,
   plugins: [reactRefreshPlugin, svgrPlugin],
   optimizeDeps: {
-    // prevent produce extra index behind the React component namespaces.
-    keepNames: true,
+    esbuildOptions: {
+      // prevent produce extra index behind the React component namespaces.
+      keepNames: true,
+    },
   },
 });

--- a/packages/pymotif/package.json
+++ b/packages/pymotif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/pymotif",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "jupyter widget bindings for the motif library",
   "keywords": [
     "jupyter",
@@ -50,7 +50,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.1",
+    "@cylynx/motif": "^0.0.4",
     "@jupyter-widgets/base": "^1.1.10 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "@reduxjs/toolkit": "^1.2.3",
     "baseui": "^9.90.0",

--- a/packages/pymotif/pymotif/_frontend.py
+++ b/packages/pymotif/pymotif/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "@cylynx/pymotif"
-module_version = "^0.0.3"
+module_version = "^0.0.4"

--- a/packages/pymotif/pymotif/_version.py
+++ b/packages/pymotif/pymotif/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Cylynx.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 0, 3)
+version_info = (0, 0, 4)
 __version__ = ".".join(map(str, version_info))

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^16.9.27",
     "@types/react-dom": "^16.9.7",
     "@vitejs/plugin-react-refresh": "^1.3.1",
-    "vite": "2.2.4"
+    "vite": "2.4.3"
   },
   "browserslist": {
     "production": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "target": "es5",
+    "target": "esnext",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## PR Type

- Upgrade graphin to 2.1.0 and g6 to 4.3.2
- Upgrade vite to 2.4.3
- Add tslib as devDependency to fix '__spreadArray' was not found in 'tslib' issue
- Changed tslib target to `esnext` instead of `es5`, otherwise it would not work with vite config

## Test Plan

Manually tested that it works for all the main packages:

- motif dev
- motif build
- demo dev
- demo build
- pymotif

