### PR TITLE
Hotfix - Canvas Size Glitch 

### DIFF
--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.7",
+    "@cylynx/motif": "^0.0.8",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [

--- a/packages/motif/src/containers/ImportWizardModal/SampleData/constant.ts
+++ b/packages/motif/src/containers/ImportWizardModal/SampleData/constant.ts
@@ -11,8 +11,7 @@ export const sampleData: SampleDataItem[] = [
       'Try displaying the data as a circle using one of the layout options.',
     key: SampleData.CIRCLE_GRAPH,
     type: 'json',
-    src:
-      'https://storage.googleapis.com/cylynx-landing-content/circle-data.png',
+    src: 'https://storage.googleapis.com/cylynx-landing-content/circle-data.png',
   },
   {
     data: DATA.TwoDataArray,
@@ -20,8 +19,7 @@ export const sampleData: SampleDataItem[] = [
     description: 'Import multiple data as in this example.',
     key: SampleData.SIMPLE_GRAPH,
     type: 'json',
-    src:
-      'https://storage.googleapis.com/cylynx-landing-content/circle-random-data.png',
+    src: 'https://storage.googleapis.com/cylynx-landing-content/circle-random-data.png',
   },
   {
     data: DATA.BankData,
@@ -30,8 +28,7 @@ export const sampleData: SampleDataItem[] = [
       'Sample banking data with transfer, ownership, payments connections and rich data types. Use a sequential layout and try out the time-series filters and playback.',
     key: SampleData.BANK,
     type: 'json',
-    src:
-      'https://storage.googleapis.com/cylynx-landing-content/bank-connections.png',
+    src: 'https://storage.googleapis.com/cylynx-landing-content/bank-connections.png',
   },
   {
     data: DATA.MiserablesData,
@@ -40,8 +37,7 @@ export const sampleData: SampleDataItem[] = [
       'Character co-occurence in Les Misérables. Try coloring the grouping and displaying the data using a force-directed plot.',
     type: 'json',
     key: SampleData.MISERABLE,
-    src:
-      'https://storage.googleapis.com/cylynx-landing-content/miserables-data.png',
+    src: 'https://storage.googleapis.com/cylynx-landing-content/miserables-data.png',
   },
   {
     data: DATA.NetworkData,
@@ -50,8 +46,7 @@ export const sampleData: SampleDataItem[] = [
       'Co-authorship network of scientists working on network theory. 1.5k nodes and 2.7k edges.',
     type: 'json',
     key: SampleData.NETWORK,
-    src:
-      'https://storage.googleapis.com/cylynx-landing-content/network-data.png',
+    src: 'https://storage.googleapis.com/cylynx-landing-content/network-data.png',
   },
   {
     data: DATA.AAData,

--- a/packages/motif/src/containers/SidePanel/Header/Header.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/Header.tsx
@@ -84,7 +84,14 @@ const Header = () => {
         </Block>
       </Block>
     ),
-    [name, onChangeName, isCanvasHasGraph, styleOptions, graphList],
+    [
+      name,
+      onChangeName,
+      isCanvasHasGraph,
+      styleOptions,
+      graphList,
+      graphFlatten,
+    ],
   );
 };
 

--- a/packages/motif/src/containers/widgets/layer.tsx
+++ b/packages/motif/src/containers/widgets/layer.tsx
@@ -154,8 +154,8 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
     const { clientWidth, clientHeight } = this.blockRef.current;
 
     // to prevent the browser round off decimals to cause overflow
-    const innerWidth: number = Math.floor(clientWidth - 1);
-    const innerHeight: number = Math.floor(clientHeight - 1);
+    const innerWidth: number = Math.floor(clientWidth);
+    const innerHeight: number = Math.floor(clientHeight);
 
     return { innerWidth, innerHeight };
   };

--- a/packages/motif/src/containers/widgets/layer.tsx
+++ b/packages/motif/src/containers/widgets/layer.tsx
@@ -154,8 +154,8 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
     const { clientWidth, clientHeight } = this.blockRef.current;
 
     // to prevent the browser round off decimals to cause overflow
-    const innerWidth: number = Math.floor(clientWidth);
-    const innerHeight: number = Math.floor(clientHeight);
+    const innerWidth: number = Math.floor(clientWidth - 1);
+    const innerHeight: number = Math.floor(clientHeight - 1);
 
     return { innerWidth, innerHeight };
   };
@@ -193,18 +193,12 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
         ref={this.blockRef}
         position='relative'
         width={width}
+        height='100%'
         paddingTop='0'
         paddingBottom='0'
         top='0'
         bottom='0'
         left={left}
-        overrides={{
-          Block: {
-            style: {
-              // overflowX: 'hidden',
-            },
-          },
-        }}
       >
         {children}
       </Block>

--- a/packages/motif/src/containers/widgets/layer.tsx
+++ b/packages/motif/src/containers/widgets/layer.tsx
@@ -154,8 +154,8 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
     const { clientWidth, clientHeight } = this.blockRef.current;
 
     // to prevent the browser round off decimals to cause overflow
-    const innerWidth: number = Math.floor(clientWidth - 1);
-    const innerHeight: number = Math.floor(clientHeight - 1);
+    const innerWidth: number = Math.floor(clientWidth);
+    const innerHeight: number = Math.floor(clientHeight);
 
     return { innerWidth, innerHeight };
   };
@@ -193,7 +193,6 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
         ref={this.blockRef}
         position='relative'
         width={width}
-        height='100%'
         paddingTop='0'
         paddingBottom='0'
         top='0'
@@ -202,7 +201,7 @@ export class GraphLayer extends Component<GraphLayerProps, GraphLayerState> {
         overrides={{
           Block: {
             style: {
-              overflowX: 'hidden',
+              // overflowX: 'hidden',
             },
           },
         }}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix
- Enhancements

## Description

- Fix export node position does not works with wrong way of memoization. 
- Fix canvas height and width scale differently in differently browser. (The previous implementation only works well in Chrome)


https://user-images.githubusercontent.com/25884538/132806123-ec234d84-df78-41f5-9213-3fc53e72b621.mov

## Technical Discussion

Implementing `100%` on div height to scale based on viewport may results in inconsistencies across different browser environment. It affects the height of the canvas that inherit it's height and caused overflow and the bug occurs show in the video. Based on the observation in the development tool, it will results in different precision in height and width of canvas if we enforce the graph layer with a `100%` height percentage. 

Therefore, the solution taken is removed the height percentage in the parent div as we already implemented `relative` position with `top:0; bottom: 0`. 

## Test Plan

- Manual test on Safari, Chrome and Opera to observe the canvas behaviours. 

