### PR TITLE
Build: Node Requirement v14

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ $ npm install --save @cylynx/motif
 | `styletron-engine-atomic` | >= 1.4.7   |
 | `styletron-react`         | >= 5.2.7   |
 
-| Development Environment | Version |
-| :---------------------- | :------ |
-| `node`                  | >=16    |
-| `npm`                   | >=7     |
+| Development Environment | Version        |
+| :---------------------- | :------------- |
+| `node`                  | ^14.0 or ^16.0 |
+| `npm`                   | >=6            |
 
 ### Usage
 

--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.10",
+    "@cylynx/motif": "^0.0.11",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -12,7 +12,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/motif.es.js",
   "engines": {
-    "node": ">=16.1"
+    "node": "^14 || ^16"
   },
   "files": [
     "dist"

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [

--- a/packages/pymotif/package.json
+++ b/packages/pymotif/package.json
@@ -50,7 +50,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.5",
+    "@cylynx/motif": "^0.0.10",
     "@jupyter-widgets/base": "^1.1.10 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "@reduxjs/toolkit": "^1.5.0",
     "baseui": "^9.90.0",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build Related Changes
- Documentation Content Chanes

## Description

Allow node requirement`v14` or `v16` to import Motif. 

- Change node requirement of Motif to allow v14 and v16 node version.
- Change the import Motif version in Pymotif from 0.0.5 to 0.0.10.

## Detailed Description

### Change node requirement of Motif to allow v14 and v16 node version.

1. Due to the constraint of `nanocolors` package, we are unable to use node v15 to import Motif. 
2. Vercel deployment only supports up to node v14.
3. We will still allow import Motif using v16.

### Change the import Motif version in Pymotif from 0.0.5 to 0.0.10.

1. The version 0.0.5 has a node requirement of `>=15.14`, which is conflicting with the node requirements during development. Thus we will need to upgrade the dependencies of pymotif to prevent incompatible node engine occurs. 

