### PR TITLE
chore: publish pymotif 0.0.6

### DIFF
--- a/packages/pymotif/package.json
+++ b/packages/pymotif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/pymotif",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "jupyter widget bindings for the motif library",
   "keywords": [
     "jupyter",

--- a/packages/pymotif/pymotif/_frontend.py
+++ b/packages/pymotif/pymotif/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "@cylynx/pymotif"
-module_version = "^0.0.5"
+module_version = "^0.0.6"

--- a/packages/pymotif/pymotif/_version.py
+++ b/packages/pymotif/pymotif/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Cylynx.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 0, 5)
+version_info = (0, 0, 6)
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Bump pymotif version to 0.0.6 and publish to pip and pypi
