### PR TITLE
Feature - Graph Snapshot Hook

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Install All Dependencies
         run: yarn install --link-duplicates
 
+      - name: View Typescript Version
+        run: npx tsc -v
+
       - name: Build Motif Bundle
         working-directory: './packages/motif'
         run: npm run build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,9 +27,6 @@ jobs:
       - name: Install All Dependencies
         run: yarn install --link-duplicates
 
-      - name: View Typescript Version
-        run: npx tsc -v
-
       - name: Build Motif Bundle
         working-directory: './packages/motif'
         run: npm run build

--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.15",
+    "@cylynx/motif": "^0.0.14",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",

--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.14",
+    "@cylynx/motif": "^0.0.15",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",

--- a/packages/motif/demo/Demo.tsx
+++ b/packages/motif/demo/Demo.tsx
@@ -43,6 +43,11 @@ const Demo = () => {
               edgeSource: 'source',
               edgeTarget: 'target',
             }}
+            // overrides={{
+            //   SidePanelHeader: (
+            //     <Block style={{ color: 'white' }}>Data to Work With</Block>
+            //   ),
+            // }}
             // onExportExternal={(exportData) => {
             //   console.log(exportData);
             // }}

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "start": "vite --force --config vite.dev.config.ts",
-    "build": "npm run clean && tsc -b && vite build --config vite.prod.config.ts",
+    "build": "npm run clean && tsc && vite build --config vite.prod.config.ts",
     "transpile": "tsc --p ./tsconfig.json --noEmit true --strict --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.15",
+  "version": "0.0.14",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [
@@ -19,8 +19,8 @@
   ],
   "scripts": {
     "start": "vite --force --config vite.dev.config.ts",
-    "build": "npm run clean && tsc && vite build --config vite.prod.config.ts",
-    "transpile": "tsc --p ./tsconfig.json --noEmit true --strict --watch",
+    "build": "npm run clean && npx -p typescript tsc && vite build --config vite.prod.config.ts",
+    "transpile": "npx -p typescript tsc --p ./tsconfig.json --strict --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage --watchAll=false",

--- a/packages/motif/src/components/Icons/Icons.tsx
+++ b/packages/motif/src/components/Icons/Icons.tsx
@@ -48,8 +48,7 @@ import { BsSlash } from 'react-icons/bs';
 import { VscSymbolKey, VscCircleOutline } from 'react-icons/vsc';
 import { AiOutlineCloudUpload, AiOutlineWarning } from 'react-icons/ai';
 import { IconBaseProps } from 'react-icons';
-import { GrDocumentCsv } from 'react-icons/gr';
-import { FaFileCode, FaFileCsv } from 'react-icons/fa';
+import { FaFileCode } from 'react-icons/fa';
 
 export const Node = ({ children, size = 16, ...rest }: IconBaseProps) => (
   <VscCircleOutline size={size} {...rest}>

--- a/packages/motif/src/components/plots/RangePlot.tsx
+++ b/packages/motif/src/components/plots/RangePlot.tsx
@@ -5,7 +5,6 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { Block } from 'baseui/block';
 import RangeBrush from './RangeBrush';
 import HistogramPlot from './HistogramPlot';
-import { Slider } from '../ui';
 import { HistogramBin } from '../../utils/data-utils/data-utils';
 import NumericAxis from './NumericAxis';
 import DateTimeAxis from './DateTimeAxis';
@@ -82,37 +81,12 @@ const RangePlot = ({
     [onChange],
   );
 
-  const onChangeSlider = useCallback(
-    (value: [number, number]) => {
-      if (value) {
-        setBrushing(false);
-        onMouseMove(null);
-        setEnableChartHover(false);
-      }
-      if (value && onChange) {
-        onChange(value);
-      }
-    },
-    [setBrushing, onMouseMove, setEnableChartHover, onChange],
-  );
-
   const onBrushEnd = useCallback(
     (v0: number, v1: number) => {
       setBrushing(false);
       setEnableChartHover(true);
       if (onFinalChange) {
         onFinalChange([v0, v1]);
-      }
-    },
-    [setBrushing, setEnableChartHover, onFinalChange],
-  );
-
-  const onFinalChangeSlider = useCallback(
-    (value: [number, number]) => {
-      setBrushing(false);
-      setEnableChartHover(true);
-      if (onFinalChange) {
-        onFinalChange(value);
       }
     },
     [setBrushing, setEnableChartHover, onFinalChange],

--- a/packages/motif/src/components/ui/Button.tsx
+++ b/packages/motif/src/components/ui/Button.tsx
@@ -1,9 +1,8 @@
-import React, { FC } from 'react';
+import React from 'react';
 import {
   Button as BaseButton,
   SHAPE,
   ButtonProps as BaseButtonProps,
-  ButtonOverrides,
 } from 'baseui/button';
 
 type ButtonProps = BaseButtonProps & {

--- a/packages/motif/src/containers/Explorer.tsx
+++ b/packages/motif/src/containers/Explorer.tsx
@@ -23,6 +23,7 @@ import {
   Overrides,
   getTooltipOverride,
   getWidgetOverride,
+  getSidePanelHeaderOverride,
 } from '../utils/overrides';
 import { UISlices } from '../redux/ui';
 import { MotifLightTheme, MotifDarkTheme } from '../theme';
@@ -110,6 +111,7 @@ const Explorer = React.forwardRef<Graphin, ExplorerProps>(
 
     const UserTooltip = getTooltipOverride(overrides, Tooltip);
     const widgetList = getWidgetOverride(overrides, defaultWidgetList);
+    const customSidePanelHeader = getSidePanelHeaderOverride(overrides);
     const activeWidgetList: WidgetItem[] =
       widgetList.filter((x: WidgetItem) => widgetStateIds.includes(x.id)) || [];
 
@@ -161,7 +163,9 @@ const Explorer = React.forwardRef<Graphin, ExplorerProps>(
           },
         }}
       >
-        <ExplorerContext.Provider value={{ onExportExternal }}>
+        <ExplorerContext.Provider
+          value={{ onExportExternal, customSidePanelHeader }}
+        >
           <DataTableModal />
           <ImportWizardModal overrideTabs={overrides?.Tabs} />
 

--- a/packages/motif/src/containers/Graph/context.tsx
+++ b/packages/motif/src/containers/Graph/context.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import Graphin from '@cylynx/graphin';
 import { TLoadFormat } from '../../redux/graph';
 
 export type ExplorerContextProps = {
   onExportExternal?: (exportData: TLoadFormat) => void;
+  customSidePanelHeader?: ReactNode;
 };
 
 /*  const graphContext = useContext(GraphRefContext); */

--- a/packages/motif/src/containers/ImportWizardModal/ErrorCollections/JsonErrors.tsx
+++ b/packages/motif/src/containers/ImportWizardModal/ErrorCollections/JsonErrors.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { Block } from 'baseui/block';
 import { useStyletron } from 'baseui';
-import { StyledLink } from 'baseui/link';
 import ErrorMessage from '../../../components/ImportErrorMessage';
 
 export const BoldCodeText: React.FC = ({ children }) => {

--- a/packages/motif/src/containers/SidePanel/FilterPanel/AddFilterButton.tsx
+++ b/packages/motif/src/containers/SidePanel/FilterPanel/AddFilterButton.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useMemo } from 'react';
-import { SIZE } from 'baseui/button';
 import * as Icon from '../../../components/Icons';
 import { Button } from '../../../components/ui';
 

--- a/packages/motif/src/containers/SidePanel/Header/Header.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/Header.tsx
@@ -1,38 +1,23 @@
 import React, { useCallback, useMemo } from 'react';
-import html2canvas from 'html2canvas';
 
 import { Block } from 'baseui/block';
 import { useDispatch, useSelector } from 'react-redux';
+import useGraphSnapshot from './useGraphSnapshot';
 import { UISelectors, UISlices } from '../../../redux/ui';
-import {
-  GraphSelectors,
-  StyleOptions,
-  GraphList,
-  GraphData,
-  FilterOptions,
-} from '../../../redux/graph';
+import { GraphSelectors, GraphList } from '../../../redux/graph';
 import * as Icon from '../../../components/Icons';
 import Editable from '../../../components/Editable';
 import HeaderButton from './HeaderButton';
 import SaveButton from './SaveButton/SaveButton';
+import { ExplorerContext } from '../../Graph/context';
 
 const Header = () => {
   const name: string = useSelector((state) => UISelectors.getUI(state).name);
+  const { exportPNG } = useGraphSnapshot();
   const graphList: GraphList = useSelector((state) =>
     GraphSelectors.getGraphList(state),
   );
 
-  const graphFlatten: GraphData = useSelector((state) =>
-    GraphSelectors.getGraphFlatten(state),
-  );
-
-  const styleOptions: StyleOptions = useSelector((state) =>
-    GraphSelectors.getStyleOptions(state),
-  );
-
-  const filterOptions: FilterOptions = useSelector((state) =>
-    GraphSelectors.getFilterOptions(state),
-  );
   const dispatch = useDispatch();
 
   const onChangeName = useCallback(
@@ -44,19 +29,6 @@ const Header = () => {
     return graphList.length > 0;
   }, [graphList.length]);
 
-  const exportPNG = useCallback(() => {
-    const graph = document.getElementById('graphin-container');
-
-    html2canvas(graph).then((canvas) => {
-      const file = document.createElement('a');
-      file.download = 'graph.png';
-      file.href = canvas.toDataURL();
-      document.body.appendChild(file);
-      file.click();
-      document.body.removeChild(file);
-    });
-  }, [isCanvasHasGraph]);
-
   return useMemo(
     () => (
       <Block
@@ -66,39 +38,38 @@ const Header = () => {
         marginBottom='scale300'
         height='scale950'
       >
-        <Block>
-          <Editable text={name} onChange={onChangeName} />
-        </Block>
-        <Block>
-          {isCanvasHasGraph && (
-            <>
-              <HeaderButton
-                key={1}
-                name='Screenshot'
-                icon={<Icon.Camera />}
-                isDisabled={false}
-                onClick={exportPNG}
-              />
-              <SaveButton
-                graphList={graphList}
-                styleOptions={styleOptions}
-                graphFlatten={graphFlatten}
-                filterOptions={filterOptions}
-              />
-            </>
-          )}
-        </Block>
+        <ExplorerContext.Consumer>
+          {({ customSidePanelHeader }) => {
+            if (!customSidePanelHeader) {
+              return (
+                <>
+                  <Block>
+                    <Editable text={name} onChange={onChangeName} />
+                  </Block>
+                  <Block>
+                    {isCanvasHasGraph && (
+                      <>
+                        <HeaderButton
+                          key={1}
+                          name='Screenshot'
+                          icon={<Icon.Camera />}
+                          isDisabled={false}
+                          onClick={exportPNG}
+                        />
+                        <SaveButton />
+                      </>
+                    )}
+                  </Block>
+                </>
+              );
+            }
+
+            return customSidePanelHeader;
+          }}
+        </ExplorerContext.Consumer>
       </Block>
     ),
-    [
-      name,
-      onChangeName,
-      isCanvasHasGraph,
-      styleOptions,
-      graphList,
-      graphFlatten,
-      filterOptions,
-    ],
+    [name, onChangeName, isCanvasHasGraph, graphList],
   );
 };
 

--- a/packages/motif/src/containers/SidePanel/Header/SaveButton/Menu.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/SaveButton/Menu.tsx
@@ -3,46 +3,19 @@ import { StatefulMenu } from 'baseui/menu';
 import React, { FC, useMemo } from 'react';
 import { colors } from 'baseui/tokens';
 import * as Label from './Labels';
-import { setGraphListPosition } from '../../../../utils/export-utils';
 import * as GraphT from '../../../../redux/graph';
 import { SaveChoicesMenuProps } from './types';
+import useGraphSnapshot from '../useGraphSnapshot';
 
 const SaveChoicesMenu: FC<SaveChoicesMenuProps> = ({
   close,
-  graphList,
-  styleOptions,
-  graphFlatten,
-  filterOptions,
   onExportExternal,
 }) => {
   const [, theme] = useStyletron();
-
-  const exportJSON = () => {
-    const positionGraphList = setGraphListPosition(graphList, graphFlatten);
-    const exportData: GraphT.TLoadFormat = {
-      data: positionGraphList,
-      style: styleOptions,
-      filter: filterOptions,
-    };
-
-    const contentType = 'application/json;charset=utf-8;';
-    const jsonInfo: string = JSON.stringify(exportData);
-    const file: HTMLAnchorElement = document.createElement('a');
-    file.download = 'graph.json';
-    file.href = `data:${contentType},${encodeURIComponent(jsonInfo)}`;
-    document.body.appendChild(file);
-    file.click();
-    document.body.removeChild(file);
-  };
+  const { exportJSON, exportCurrentData } = useGraphSnapshot();
 
   const saveToCloud = () => {
-    const positionGraphList = setGraphListPosition(graphList, graphFlatten);
-    const exportData: GraphT.TLoadFormat = {
-      data: positionGraphList,
-      style: styleOptions,
-      filter: filterOptions,
-    };
-
+    const exportData: GraphT.TLoadFormat = exportCurrentData();
     onExportExternal(exportData);
   };
 
@@ -62,7 +35,7 @@ const SaveChoicesMenu: FC<SaveChoicesMenuProps> = ({
     }
 
     return items;
-  }, [graphList, styleOptions, exportJSON, theme, graphFlatten, filterOptions]);
+  }, [exportJSON, theme]);
 
   return (
     <StatefulMenu

--- a/packages/motif/src/containers/SidePanel/Header/SaveButton/SaveButton.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/SaveButton/SaveButton.tsx
@@ -5,14 +5,8 @@ import { ExplorerContext } from '../../../Graph/context';
 import * as Icon from '../../../../components/Icons';
 import HeaderButton from '../HeaderButton';
 import SaveChoicesMenu from './Menu';
-import { SaveButtonProps } from './types';
 
-const SaveButton = ({
-  graphList,
-  styleOptions,
-  graphFlatten,
-  filterOptions,
-}: SaveButtonProps) => {
+const SaveButton = () => {
   return (
     <StatefulPopover
       focusLock
@@ -23,10 +17,6 @@ const SaveButton = ({
           {({ onExportExternal }) => (
             <SaveChoicesMenu
               close={close}
-              graphList={graphList}
-              graphFlatten={graphFlatten}
-              styleOptions={styleOptions}
-              filterOptions={filterOptions}
               onExportExternal={onExportExternal}
             />
           )}

--- a/packages/motif/src/containers/SidePanel/Header/SaveButton/types.ts
+++ b/packages/motif/src/containers/SidePanel/Header/SaveButton/types.ts
@@ -1,13 +1,8 @@
 import { Theme } from 'baseui/theme';
 import { ExplorerContextProps } from 'src/containers/Graph/context';
-import * as GraphT from '../../../../redux/graph';
 
 export type SaveChoicesMenuProps = { close: any } & SaveButtonProps;
 export type SaveButtonProps = {
-  graphList: GraphT.GraphList;
-  graphFlatten: GraphT.GraphData;
-  styleOptions: GraphT.StyleOptions;
-  filterOptions: GraphT.FilterOptions;
   onExportExternal?: ExplorerContextProps['onExportExternal'];
 };
 export type LabelProps = { theme: Theme };

--- a/packages/motif/src/containers/SidePanel/Header/index.ts
+++ b/packages/motif/src/containers/SidePanel/Header/index.ts
@@ -1,3 +1,5 @@
 import Header from './Header';
+import useGraphSnapshot from './useGraphSnapshot';
 
+export { useGraphSnapshot };
 export default Header;

--- a/packages/motif/src/containers/SidePanel/Header/useGraphSnapshot.tsx
+++ b/packages/motif/src/containers/SidePanel/Header/useGraphSnapshot.tsx
@@ -1,0 +1,58 @@
+import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import html2canvas from 'html2canvas';
+import { setGraphListPosition } from '../../../utils/export-utils';
+import * as GraphT from '../../../redux/graph';
+import { GraphSelectors } from '../../../redux/graph';
+
+const useGraphSnapshot = () => {
+  const { graphList, styleOptions, graphFlatten, filterOptions } = useSelector(
+    GraphSelectors.getGraph,
+  );
+
+  const exportJSON = () => {
+    const positionGraphList = setGraphListPosition(graphList, graphFlatten);
+    const exportData: GraphT.TLoadFormat = {
+      data: positionGraphList,
+      style: styleOptions,
+      filter: filterOptions,
+    };
+
+    const contentType = 'application/json;charset=utf-8;';
+    const jsonInfo: string = JSON.stringify(exportData);
+    const file: HTMLAnchorElement = document.createElement('a');
+    file.download = 'graph.json';
+    file.href = `data:${contentType},${encodeURIComponent(jsonInfo)}`;
+    document.body.appendChild(file);
+    file.click();
+    document.body.removeChild(file);
+  };
+
+  const exportCurrentData = () => {
+    const positionGraphList = setGraphListPosition(graphList, graphFlatten);
+    const exportData: GraphT.TLoadFormat = {
+      data: positionGraphList,
+      style: styleOptions,
+      filter: filterOptions,
+    };
+
+    return exportData;
+  };
+
+  const exportPNG = useCallback(() => {
+    const graph = document.getElementById('graphin-container');
+
+    html2canvas(graph).then((canvas) => {
+      const file = document.createElement('a');
+      file.download = 'graph.png';
+      file.href = canvas.toDataURL();
+      document.body.appendChild(file);
+      file.click();
+      document.body.removeChild(file);
+    });
+  }, []);
+
+  return { exportJSON, exportCurrentData, exportPNG };
+};
+
+export default useGraphSnapshot;

--- a/packages/motif/src/containers/SidePanel/SearchPanel/Components/EdgeInfoAccordion.tsx
+++ b/packages/motif/src/containers/SidePanel/SearchPanel/Components/EdgeInfoAccordion.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import Accordion from '../../../../components/Accordion';
-import * as Icon from '../../../../components/Icons';
 import { EdgeInformation } from '../../../../redux/graph';
 import useItemInformation from '../hooks/useItemInformation';
 

--- a/packages/motif/src/containers/SidePanel/SearchPanel/Section/ItemResults/ItemResults.tsx
+++ b/packages/motif/src/containers/SidePanel/SearchPanel/Section/ItemResults/ItemResults.tsx
@@ -3,6 +3,7 @@ import { Block, BlockOverrides } from 'baseui/block';
 import { useSelector } from 'react-redux';
 import { Theme } from 'baseui/theme';
 import { INode, IEdge } from '@antv/g6';
+import { RootState } from '../../../../../redux';
 import { GraphSelectors } from '../../../../../redux/graph';
 import { GraphRefContext } from '../../../../Graph/context';
 import useGraphBehaviors from '../../../../Graph/hooks/useGraphBehaviors';
@@ -20,7 +21,7 @@ const itemBlockOverrides: BlockOverrides = {
 };
 
 const ItemResults: FC = () => {
-  const { nodes, edges } = useSelector((state) =>
+  const { nodes, edges } = useSelector((state: RootState) =>
     GraphSelectors.getPaginateItems(state),
   );
 

--- a/packages/motif/src/containers/SidePanel/SearchPanel/hooks/useItemInformation.tsx
+++ b/packages/motif/src/containers/SidePanel/SearchPanel/hooks/useItemInformation.tsx
@@ -3,44 +3,11 @@ import { Block } from 'baseui/block';
 import { NodeStyle } from '@cylynx/graphin';
 import { darken } from 'polished';
 import { LabelMedium, ParagraphSmall } from 'baseui/typography';
-import { Theme } from 'baseui/theme';
 import shortid from 'shortid';
 import { Node, Edge, NodeItemType, EdgeNode } from '../../../../redux/graph';
 import { flattenObject } from '../../../../redux/graph/processors/data';
 import { removeEmptyValueInObject } from '../../../../utils/data-utils/data-utils';
 import * as Icon from '../../../../components/Icons';
-
-/**
- * This component is leave for future implementation for better UI/UX.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
-const EdgeShape = () => {
-  return (
-    <Block top='-14px' left='4px' position='absolute'>
-      <Block
-        height='45px'
-        backgroundColor='contentTertiary'
-        marginLeft='3px'
-        width='2px'
-      />
-      <Block
-        width='0'
-        height='0'
-        overrides={{
-          Block: {
-            style: ({ $theme }: { $theme: Theme }) => {
-              return {
-                borderLeft: `${$theme.sizing.scale100} solid transparent`,
-                borderRight: `${$theme.sizing.scale100} solid transparent`,
-                borderTop: `${$theme.sizing.scale100} solid ${$theme.colors.contentTertiary}`,
-              };
-            },
-          },
-        }}
-      />
-    </Block>
-  );
-};
 
 type NodeShapeProps = { fill: string; borderColor: string };
 const NodeShape = ({ fill, borderColor }: NodeShapeProps) => {

--- a/packages/motif/src/index.ts
+++ b/packages/motif/src/index.ts
@@ -14,6 +14,8 @@ import { json2csv, processCsvData } from './redux/graph/processors/data';
 import { MotifDarkTheme, MotifLightTheme } from './theme';
 import useGraphBehaviors from './containers/Graph/hooks/useGraphBehaviors';
 
+import { useGraphSnapshot } from './containers/SidePanel/Header';
+
 // eslint-disable-next-line prettier/prettier
 export type { TableTabItem, StepperItems, ExplorerProps };
 export {
@@ -32,6 +34,7 @@ export {
   json2csv,
   processCsvData,
   useGraphBehaviors,
+  useGraphSnapshot,
 };
 
 export { MotifDarkTheme, MotifLightTheme };

--- a/packages/motif/src/redux/graph/interfaces.ts
+++ b/packages/motif/src/redux/graph/interfaces.ts
@@ -1,13 +1,53 @@
 import { OutputSelector } from '@reduxjs/toolkit';
+import { Option } from 'baseui/select';
 import * as GraphT from './types';
 
 export interface IGraphSelector {
   getPaginateItems: OutputSelector<
-    any,
+    [
+      (state: any) => GraphT.ItemProperties,
+      (state: any) => GraphT.SearchOptPagination,
+    ],
     GraphT.ItemProperties,
     (
       selectedItems: GraphT.ItemProperties,
       pagination: GraphT.SearchOptPagination,
     ) => GraphT.ItemProperties
+  >;
+
+  getGraphFiltered: OutputSelector<
+    [(state: any) => GraphT.GraphData, (state: any) => GraphT.FilterOptions],
+    GraphT.GraphData,
+    (
+      graphFlatten: GraphT.GraphData,
+      filerOptions: GraphT.FilterOptions,
+    ) => GraphT.GraphData
+  >;
+
+  getGraphVisible: OutputSelector<
+    [(state: any) => GraphT.GraphData, (state: any) => GraphT.StyleOptions],
+    GraphT.GraphData,
+    (
+      graphFiltered: GraphT.GraphData,
+      styleOptions: GraphT.StyleOptions,
+    ) => GraphT.GraphData
+  >;
+
+  getGraphVisibleNodeOptions: OutputSelector<
+    [(state: any) => GraphT.GraphData],
+    Option[],
+    (graphVisible: GraphT.GraphData) => Option[]
+  >;
+
+  getGraphFieldsOptions: OutputSelector<
+    [(state: any) => GraphT.GraphData],
+    any,
+    (graphFlatten: GraphT.GraphData) => any
+  >;
+
+  getUngroupedGraphFlatten: OutputSelector<
+    [(state: any) => GraphT.GraphList],
+    GraphT.GraphData,
+    (graphList: GraphT.GraphList) => GraphT.GraphData
   >;
 }

--- a/packages/motif/src/redux/graph/interfaces.ts
+++ b/packages/motif/src/redux/graph/interfaces.ts
@@ -1,0 +1,13 @@
+import { OutputSelector } from '@reduxjs/toolkit';
+import * as GraphT from './types';
+
+export interface IGraphSelector {
+  getPaginateItems: OutputSelector<
+    any,
+    GraphT.ItemProperties,
+    (
+      selectedItems: GraphT.ItemProperties,
+      pagination: GraphT.SearchOptPagination,
+    ) => GraphT.ItemProperties
+  >;
+}

--- a/packages/motif/src/redux/graph/processors/group-edges.ts
+++ b/packages/motif/src/redux/graph/processors/group-edges.ts
@@ -1,4 +1,4 @@
-import { isEmpty, get, set, cloneDeep, uniqBy, uniq } from 'lodash';
+import { isEmpty, get, set, cloneDeep, uniqBy } from 'lodash';
 import {
   Edge,
   FieldAndAggregation,

--- a/packages/motif/src/redux/graph/selectors.ts
+++ b/packages/motif/src/redux/graph/selectors.ts
@@ -19,6 +19,7 @@ import {
   getField,
   combineProcessedData,
 } from '../../utils/graph-utils/utils';
+import { IGraphSelector } from './interfaces';
 
 const getGraph = (state: any): GraphState => state.investigate.graph.present;
 const getAccessors = (state: any): Accessors => getGraph(state).accessors;
@@ -37,7 +38,7 @@ const getSelectedItems = (state: any): ItemProperties =>
 const getItemsPagination = (state: any): SearchOptPagination =>
   getSearchOptions(state).pagination;
 
-const getPaginateItems = createSelector(
+const getPaginateItems: IGraphSelector['getPaginateItems'] = createSelector(
   [getSelectedItems, getItemsPagination],
   (selectedItems: ItemProperties, pagination: SearchOptPagination) => {
     const paginatedItems = paginateItems(selectedItems, pagination);
@@ -46,7 +47,7 @@ const getPaginateItems = createSelector(
 );
 
 /** Selector to get graph data after it is filtered */
-const getGraphFiltered = createSelector(
+const getGraphFiltered: IGraphSelector['getGraphFiltered'] = createSelector(
   [getGraphFlatten, getFilterOptions],
   (graphFlatten: GraphData, filterOptions: FilterOptions) => {
     const graphFiltered = produce(graphFlatten, (draftState: GraphData) => {
@@ -58,7 +59,7 @@ const getGraphFiltered = createSelector(
 );
 
 /** Selector to derive visible data */
-const getGraphVisible = createSelector(
+const getGraphVisible: IGraphSelector['getGraphVisible'] = createSelector(
   [getGraphFiltered, getStyleOptions],
   (graphFiltered: GraphData, styleOptions: StyleOptions) => {
     const graphVisible = produce(graphFiltered, (draftState: GraphData) => {
@@ -70,20 +71,17 @@ const getGraphVisible = createSelector(
 );
 
 /** Selector to derive visible node ids */
-const getGraphVisibleNodeOptions = createSelector(
-  [getGraphVisible],
-  (graphVisible: GraphData) => {
+const getGraphVisibleNodeOptions: IGraphSelector['getGraphVisibleNodeOptions'] =
+  createSelector([getGraphVisible], (graphVisible: GraphData) => {
     const nodeIdOptions: Option[] = graphVisible.nodes.map((n) => {
       return { id: n.id, label: n.id };
     });
     return nodeIdOptions;
-  },
-);
+  });
 
 /** Selector to get node fields as select options */
-const getGraphFieldsOptions = createSelector(
-  [getGraphFlatten],
-  (graphFlatten: GraphData) => {
+const getGraphFieldsOptions: IGraphSelector['getGraphFieldsOptions'] =
+  createSelector([getGraphFlatten], (graphFlatten: GraphData) => {
     const graphFields = graphFlatten.metadata.fields;
 
     const allNodeFields: Option[] = [{ id: 'id', label: 'id' }];
@@ -127,13 +125,11 @@ const getGraphFieldsOptions = createSelector(
       edgeLabelFields,
       numericEdgeFields,
     };
-  },
-);
+  });
 
 // obtain the ungroup edges graph flatten
-const getUngroupedGraphFlatten = createSelector(
-  [getGraphList],
-  (graphList: GraphList) => {
+const getUngroupedGraphFlatten: IGraphSelector['getUngroupedGraphFlatten'] =
+  createSelector([getGraphList], (graphList: GraphList) => {
     let ungroupedGraphFlatten: GraphData = {
       nodes: [],
       edges: [],
@@ -147,8 +143,7 @@ const getUngroupedGraphFlatten = createSelector(
     });
 
     return ungroupedGraphFlatten;
-  },
-);
+  });
 
 export {
   getGraph,

--- a/packages/motif/src/redux/graph/selectors.ts
+++ b/packages/motif/src/redux/graph/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, OutputSelector } from '@reduxjs/toolkit';
+import { createSelector } from '@reduxjs/toolkit';
 import { Option } from 'baseui/select';
 import produce from 'immer';
 import {
@@ -37,14 +37,7 @@ const getSelectedItems = (state: any): ItemProperties =>
 const getItemsPagination = (state: any): SearchOptPagination =>
   getSearchOptions(state).pagination;
 
-const getPaginateItems: OutputSelector<
-  any,
-  ItemProperties,
-  (
-    selectedItems: ItemProperties,
-    pagination: SearchOptPagination,
-  ) => ItemProperties
-> = createSelector(
+const getPaginateItems = createSelector(
   [getSelectedItems, getItemsPagination],
   (selectedItems: ItemProperties, pagination: SearchOptPagination) => {
     const paginatedItems = paginateItems(selectedItems, pagination);

--- a/packages/motif/src/redux/graph/selectors.ts
+++ b/packages/motif/src/redux/graph/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector } from '@reduxjs/toolkit';
+import { createSelector, OutputSelector } from '@reduxjs/toolkit';
 import { Option } from 'baseui/select';
 import produce from 'immer';
 import {
@@ -37,7 +37,14 @@ const getSelectedItems = (state: any): ItemProperties =>
 const getItemsPagination = (state: any): SearchOptPagination =>
   getSearchOptions(state).pagination;
 
-const getPaginateItems = createSelector(
+const getPaginateItems: OutputSelector<
+  any,
+  ItemProperties,
+  (
+    selectedItems: ItemProperties,
+    pagination: SearchOptPagination,
+  ) => ItemProperties
+> = createSelector(
   [getSelectedItems, getItemsPagination],
   (selectedItems: ItemProperties, pagination: SearchOptPagination) => {
     const paginatedItems = paginateItems(selectedItems, pagination);

--- a/packages/motif/src/theme/baseui-light.ts
+++ b/packages/motif/src/theme/baseui-light.ts
@@ -1,5 +1,4 @@
 import { createLightTheme } from 'baseui';
-import { Theme } from 'baseui/theme';
 import typography from './shared/typography';
 import borders from './shared/borders';
 import themeColors from './shared/themeColors';

--- a/packages/motif/src/utils/overrides.tsx
+++ b/packages/motif/src/utils/overrides.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { TooltipProps } from '../containers/Tooltip';
 import { WidgetItem } from '../redux/widget';
@@ -8,6 +8,7 @@ export interface Overrides {
   Tabs?: ImportTabs[];
   Tooltip?: React.ComponentType<{ tooltip: TooltipProps }>;
   widgetList?: WidgetItem[];
+  SidePanelHeader?: ReactNode;
 }
 
 export const getTabsOverride = (
@@ -29,4 +30,10 @@ export const getWidgetOverride = (
   defaultWidgetList: WidgetItem[],
 ): WidgetItem[] => {
   return overrides?.widgetList || defaultWidgetList;
+};
+
+export const getSidePanelHeaderOverride = (
+  overrides: Overrides,
+): ReactNode | undefined => {
+  return overrides?.SidePanelHeader;
 };

--- a/packages/motif/tsconfig.json
+++ b/packages/motif/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitAny": false,
     "noEmit": false,
     "types": ["@types/node", "@types/react", "@types/jest"],
-    "noEmitOnError": true
+    "noEmitOnError": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
   "exclude": [

--- a/packages/motif/vite.prod.config.ts
+++ b/packages/motif/vite.prod.config.ts
@@ -36,8 +36,8 @@ export default defineConfig({
   build: {
     outDir: outputDir,
 
-    // generate source map for debugging in the client
-    sourcemap: true,
+    // remove source map for debugging in the client to reduce package size
+    sourcemap: false,
     minify: 'terser',
 
     // prevent empty output directory as it contains typescript declarations.

--- a/packages/ui/src/theme/baseui-light.ts
+++ b/packages/ui/src/theme/baseui-light.ts
@@ -1,5 +1,4 @@
 import { createLightTheme } from 'baseui';
-import { Theme } from 'baseui/theme';
 import typography from './shared/typography';
 import borders from './shared/borders';
 import themeColors from './shared/themeColors';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noImplicitAny": true,
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "allowJs": true,
     "strict": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "esModuleInterop": true,
     "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noImplicitAny": true,
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Features
- Enhancements
- Code Style Changes

## Description

- Provide flexibilities for client to use the function to take a snapshot on the current graph state, and store the graph state into a local file format which is loadable by the import features. 
- Allow client to customise the side panel header with own components.

## Detailed Description

- The **Screenshot**, **Save to Cloud** and **Export to JSON** feature are migrated into `useGraphSnapshot` hook, the hook is export for client to perform the mentioned function. 

## Technical Discussion

- The **Screenshot**, **Save to Cloud** and **Export to JSON** feature are migrated into `useGraphSnapshot` hook, the hook is export for client to perform the mentioned function. 
- Expose a `overrides.SidePanelHeader` props allow client to override the side panel header.

```ts
          <Motif
            name='Motif'
            primaryTheme={MotifLightTheme}
            secondaryTheme={MotifDarkTheme}
            accessors={{
              nodeID: 'id',
              edgeSource: 'source',
              edgeTarget: 'target',
            }}
            overrides={{
              // allow client to modify the side panel header with own component. 
               SidePanelHeader: (
                 <Block style={{ color: 'white' }}>Data to Work With</Block>
               ),
             }}
          />
```

![Screenshot 2021-11-08 at 4 24 42 PM](https://user-images.githubusercontent.com/25884538/140709109-db3f3754-3134-46cf-b9ed-469247efe2ca.png)



## Does this PR introduce breaking change?

- No, the refactor should not break all the existing implementation and integration. 

