### PR TITLE
Feature - Change Node/Edge Colour with Colour Picker

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
     '@typescript-eslint/no-shadow': 'off',
     'no-useless-return': 'off',
     'import/no-extraneous-dependencies': 'off',
+    'jsx-a11y/click-events-have-key-events': 'off',
     'max-len': [
       'warn',
       {

--- a/packages/motif-demo/package.json
+++ b/packages/motif-demo/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview --port 3000"
   },
   "dependencies": {
-    "@cylynx/motif": "^0.0.16",
+    "@cylynx/motif": "^0.0.17",
     "@reduxjs/toolkit": "^1.2.3",
     "attr-accept": "^2.2.2",
     "baseui": "^9.90.0",

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cylynx/motif",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "An out of the box graph visualization toolkit to assist analysis and investigation of network data.",
   "author": "Timothy Lin",
   "keywords": [

--- a/packages/motif/package.json
+++ b/packages/motif/package.json
@@ -51,6 +51,7 @@
     "lodash-es": "^4.17.15",
     "polished": "^4.0.3",
     "postcss": "^8.2.10",
+    "react-color-palette": "^6.2.0",
     "react-hook-form": "^7.3.4",
     "react-icons": "^4.2.0",
     "react-redux": "^7.1.3",

--- a/packages/motif/src/components/Icons/Icons.tsx
+++ b/packages/motif/src/components/Icons/Icons.tsx
@@ -49,6 +49,7 @@ import { VscSymbolKey, VscCircleOutline } from 'react-icons/vsc';
 import { AiOutlineCloudUpload, AiOutlineWarning } from 'react-icons/ai';
 import { IconBaseProps } from 'react-icons';
 import { FaFileCode } from 'react-icons/fa';
+import { ImCross } from 'react-icons/im';
 
 export const Node = ({ children, size = 16, ...rest }: IconBaseProps) => (
   <VscCircleOutline size={size} {...rest}>
@@ -359,3 +360,11 @@ export const UploadCloud = ({
     {children}
   </AiOutlineCloudUpload>
 );
+
+export const Cross = ({ size = 16, children, ...rest }: IconBaseProps) => {
+  return (
+    <ImCross size={size} {...rest}>
+      {children}
+    </ImCross>
+  );
+};

--- a/packages/motif/src/components/Legend/Legend.tsx
+++ b/packages/motif/src/components/Legend/Legend.tsx
@@ -1,18 +1,13 @@
-import React from 'react';
-import { useStyletron } from 'baseui';
-import { Block } from 'baseui/block';
-import { LabelSmall } from 'baseui/typography';
+import React, { useState } from 'react';
 
-type LegendProps = {
-  data: { [_: string]: string };
-  colorMap: string[];
-  kind: 'node' | 'edge';
-  maxSize?: number;
-  label?: string;
-};
+import { LabelSmall } from 'baseui/typography';
+import { Block } from 'baseui/block';
+import { LegendProps } from './type';
+import ObjectColours from './ObjectColours';
+import ObjectColourPicker from './ObjectColourPicker';
 
 const Legend = ({ data, colorMap, kind, maxSize = 8, label }: LegendProps) => {
-  const [css] = useStyletron();
+  const [showPicker, setShowPicker] = useState(false);
   let valueArr = Object.keys(data);
   let colorArr = Object.values(data);
   if (valueArr.length > maxSize) {
@@ -21,49 +16,51 @@ const Legend = ({ data, colorMap, kind, maxSize = 8, label }: LegendProps) => {
     colorArr = colorArr.slice(0, maxSize);
     colorArr.push(colorMap[maxSize - 1]);
   }
+
   return (
-    <>
-      {label && (
-        <LabelSmall
-          marginBottom='scale100'
-          marginTop='scale200'
-          marginRight='scale200'
-          color='contentInverseSecondary'
-        >
-          {label}
-        </LabelSmall>
+    <div>
+      <Block display={showPicker ? 'none' : 'block'}>
+        {label && (
+          <LabelSmall
+            marginBottom='scale100'
+            marginTop='scale200'
+            marginRight='scale200'
+            color='contentInverseSecondary'
+          >
+            {label}
+          </LabelSmall>
+        )}
+        {valueArr.map((value, i) => (
+          <ObjectColours
+            key={value}
+            value={value}
+            kind={kind}
+            onClick={() => setShowPicker(true)}
+            backgroundColor={colorArr[i]}
+          />
+        ))}
+      </Block>
+
+      {showPicker && (
+        <>
+          <LabelSmall
+            marginBottom='scale100'
+            marginTop='scale200'
+            marginRight='scale200'
+            color='contentInverseSecondary'
+          >
+            Change a <span style={{ textTransform: 'capitalize' }}>{kind}</span>{' '}
+            Color
+          </LabelSmall>
+
+          <ObjectColourPicker
+            onComplete={() => {
+              setShowPicker(false);
+            }}
+          />
+        </>
       )}
-      {valueArr.map((value, i) => (
-        <Block key={value} display='flex' alignItems='center' height='24px'>
-          {kind === 'node' && (
-            <div
-              className={css({
-                height: '16px',
-                width: '16px',
-                marginRight: '6px',
-                marginTop: '4px',
-                marginBottom: '4px',
-                backgroundColor: colorArr[i],
-                borderRadius: '50%',
-              })}
-            />
-          )}
-          {kind === 'edge' && (
-            <div
-              className={css({
-                height: '8px',
-                width: '24px',
-                marginRight: '6px',
-                marginTop: '4px',
-                marginBottom: '4px',
-                backgroundColor: colorArr[i],
-              })}
-            />
-          )}
-          <LabelSmall>{value}</LabelSmall>
-        </Block>
-      ))}
-    </>
+    </div>
   );
 };
 

--- a/packages/motif/src/components/Legend/Legend.tsx
+++ b/packages/motif/src/components/Legend/Legend.tsx
@@ -13,6 +13,7 @@ const Legend = ({
   maxSize = 8,
   label,
   onChangeColor,
+  isAllowChangeColor = true,
 }: LegendProps) => {
   const [showPicker, setShowPicker] = useState(false);
   const selectedAttrRef = useRef<[string, string]>([undefined, undefined]);
@@ -65,6 +66,7 @@ const Legend = ({
               kind={kind}
               onClick={() => openColourPicker(attrKey, colorHex)}
               backgroundColor={colorHex}
+              disableClick={!isAllowChangeColor}
             />
           );
         })}

--- a/packages/motif/src/components/Legend/Legend.tsx
+++ b/packages/motif/src/components/Legend/Legend.tsx
@@ -30,7 +30,7 @@ const Legend = ({
     }
 
     return colorMaps;
-  }, [data, colorMap, maxSize]);
+  }, [data, colorMap, maxSize, onChangeColor]);
 
   const openColourPicker = (attrLabel: string, colorHex: string) => {
     const selectedAttr = [attrLabel, colorHex] as [string, string];

--- a/packages/motif/src/components/Legend/Legend.tsx
+++ b/packages/motif/src/components/Legend/Legend.tsx
@@ -25,7 +25,7 @@ const Legend = ({
       const sliceMaps = colorMaps.slice(0, maxSize);
       const lastColorHex = colorMap[maxSize - 1];
 
-      sliceMaps[maxSize] = ['Others', lastColorHex];
+      sliceMaps[maxSize] = ['Others', data.Others ?? lastColorHex];
       return sliceMaps;
     }
 

--- a/packages/motif/src/components/Legend/Legend.tsx
+++ b/packages/motif/src/components/Legend/Legend.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 
 import { LabelSmall } from 'baseui/typography';
 import { Block } from 'baseui/block';
@@ -13,6 +13,7 @@ const Legend = ({
   maxSize = 8,
   label,
   onChangeColor,
+  variable = '',
   isAllowChangeColor = true,
 }: LegendProps) => {
   const [showPicker, setShowPicker] = useState(false);
@@ -42,6 +43,10 @@ const Legend = ({
     selectedAttrRef.current = [undefined, undefined];
     setShowPicker(false);
   };
+
+  useEffect(() => {
+    closeColourPicker();
+  }, [variable]);
 
   return (
     <div>

--- a/packages/motif/src/components/Legend/ObjectColourPicker.css
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.css
@@ -1,0 +1,17 @@
+.rcp,
+.rcp-radius,
+.rcp-saturation {
+  border-radius: 4px !important;
+  font-family: 'Poppins';
+}
+
+.rcp-body {
+  gap: 10px !important;
+  width: 100%;
+  padding: 8px 16px;
+}
+
+.rcp-fields-element-input {
+  font-weight: 500;
+  padding: 6px;
+}

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -1,0 +1,41 @@
+import { Color, ColorPicker, useColor } from 'react-color-palette';
+import React, { FC } from 'react';
+import 'react-color-palette/lib/css/styles.css';
+import './ObjectColourPicker.css';
+import { Block } from 'baseui/block';
+import { Button } from '../ui';
+import * as Icons from '../Icons';
+
+export type ObjectColourPickerProps = {
+  onComplete: (color: Color) => void;
+};
+
+const ObjectColourPicker: FC<ObjectColourPickerProps> = ({ onComplete }) => {
+  const [color, setColor] = useColor('hex', '#121212');
+
+  return (
+    <Block>
+      <ColorPicker
+        width={260}
+        height={200}
+        color={color}
+        onChange={setColor}
+        hideHSV
+        hideRGB
+        dark
+      />
+
+      <Block marginTop='scale300' display='flex' gridGap='scale200'>
+        <Button kind='secondary' onClick={() => onComplete(color)} width='100%'>
+          Cancel
+        </Button>
+        <Button kind='primary' onClick={() => onComplete(color)} width='100%'>
+          <Icons.CheckCircle size={14} />
+          <span style={{ marginLeft: '4px', paddingTop: '2px' }}>Done</span>
+        </Button>
+      </Block>
+    </Block>
+  );
+};
+
+export default ObjectColourPicker;

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -6,14 +6,7 @@ import { Block } from 'baseui/block';
 import { LabelSmall } from 'baseui/typography';
 import { Button } from '../ui';
 import * as Icons from '../Icons';
-
-type ColorMaps = [string, string];
-export type ObjectColourPickerProps = {
-  selectedAttr: ColorMaps;
-  onChangeColor: (target: ColorMaps) => void;
-  onComplete: (confirmedColor: ColorMaps) => void;
-  onCancel: (defaultColor: ColorMaps) => void;
-};
+import { ColorMaps, ObjectColourPickerProps } from './type';
 
 const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
   selectedAttr,

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -45,7 +45,7 @@ const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
         setColor(color);
         const targetChange = [attrKey, color.hex] as ColorMaps;
         onChangeColor(targetChange);
-      }, 250),
+      }, 100),
     [attrKey],
   );
 

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -32,8 +32,6 @@ const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
   const onCancelClick = () => {
     const defaultColor = [attrKey, defaultHex] as ColorMaps;
 
-    if (defaultHex === color.hex) return;
-
     onCancel(defaultColor);
   };
 

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -57,12 +57,12 @@ const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
 
       <Block marginTop='scale300' display='flex' gridGap='scale200'>
         <Button kind='secondary' onClick={onCancelClick} width='100%'>
-          <Icons.Trash size={14} />
+          <Icons.Cross size={10} />
           <ButtonText>Cancel</ButtonText>
         </Button>
         <Button kind='primary' onClick={onConfirmClick} width='100%'>
           <Icons.CheckCircle size={14} />
-          <ButtonText>Done</ButtonText>
+          <ButtonText>Apply</ButtonText>
         </Button>
       </Block>
     </Block>

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -1,40 +1,86 @@
-import { Color, ColorPicker, useColor } from 'react-color-palette';
+import { ColorPicker, useColor } from 'react-color-palette';
 import React, { FC } from 'react';
 import 'react-color-palette/lib/css/styles.css';
 import './ObjectColourPicker.css';
 import { Block } from 'baseui/block';
+import { LabelSmall } from 'baseui/typography';
 import { Button } from '../ui';
 import * as Icons from '../Icons';
 
+type ColorMaps = [string, string];
 export type ObjectColourPickerProps = {
-  onComplete: (color: Color) => void;
+  selectedAttr: ColorMaps;
+  onChangeColor: (target: ColorMaps) => void;
+  onComplete: (confirmedColor: ColorMaps) => void;
+  onCancel: (defaultColor: ColorMaps) => void;
 };
 
-const ObjectColourPicker: FC<ObjectColourPickerProps> = ({ onComplete }) => {
-  const [color, setColor] = useColor('hex', '#121212');
+const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
+  selectedAttr,
+  onChangeColor,
+  onCancel,
+  onComplete,
+}) => {
+  const [attrKey, defaultHex] = selectedAttr;
+  const [color, setColor] = useColor('hex', defaultHex);
+
+  const onChangeComplete = () => {
+    const targetChange = [attrKey, color.hex] as ColorMaps;
+    onChangeColor(targetChange);
+  };
+
+  const onCancelClick = () => {
+    const defaultColor = [attrKey, defaultHex] as ColorMaps;
+
+    if (defaultHex === color.hex) return;
+
+    onCancel(defaultColor);
+  };
+
+  const onConfirmClick = () => {
+    const targetChange = [attrKey, color.hex] as ColorMaps;
+    onComplete(targetChange);
+  };
 
   return (
     <Block>
+      <LabelSmall
+        marginBottom='scale100'
+        marginTop='scale300'
+        marginRight='scale200'
+        color='contentInverseSecondary'
+      >
+        Change <span style={{ textTransform: 'capitalize' }}>{attrKey}</span>{' '}
+        Color
+      </LabelSmall>
       <ColorPicker
         width={260}
         height={200}
         color={color}
         onChange={setColor}
+        onChangeComplete={onChangeComplete}
         hideHSV
         hideRGB
         dark
       />
 
       <Block marginTop='scale300' display='flex' gridGap='scale200'>
-        <Button kind='secondary' onClick={() => onComplete(color)} width='100%'>
-          Cancel
+        <Button kind='secondary' onClick={onCancelClick} width='100%'>
+          <Icons.Trash size={14} />
+          <ButtonText>Cancel</ButtonText>
         </Button>
-        <Button kind='primary' onClick={() => onComplete(color)} width='100%'>
+        <Button kind='primary' onClick={onConfirmClick} width='100%'>
           <Icons.CheckCircle size={14} />
-          <span style={{ marginLeft: '4px', paddingTop: '2px' }}>Done</span>
+          <ButtonText>Done</ButtonText>
         </Button>
       </Block>
     </Block>
+  );
+};
+
+const ButtonText: FC = ({ children }) => {
+  return (
+    <span style={{ marginLeft: '4px', paddingTop: '2px' }}>{children}</span>
   );
 };
 

--- a/packages/motif/src/components/Legend/ObjectColourPicker.tsx
+++ b/packages/motif/src/components/Legend/ObjectColourPicker.tsx
@@ -4,6 +4,7 @@ import 'react-color-palette/lib/css/styles.css';
 import './ObjectColourPicker.css';
 import { Block } from 'baseui/block';
 import { LabelSmall } from 'baseui/typography';
+import { OnChangeCallback } from 'react-color-palette/lib/interfaces/ColorPicker.interface';
 import { Button } from '../ui';
 import * as Icons from '../Icons';
 import { ColorMaps, ObjectColourPickerProps } from './type';
@@ -17,7 +18,7 @@ const ObjectColourPicker: FC<ObjectColourPickerProps> = ({
   const [attrKey, defaultHex] = selectedAttr;
   const [color, setColor] = useColor('hex', defaultHex);
 
-  const onChangeComplete = () => {
+  const onChangeComplete: OnChangeCallback = (color) => {
     const targetChange = [attrKey, color.hex] as ColorMaps;
     onChangeColor(targetChange);
   };

--- a/packages/motif/src/components/Legend/ObjectColours.tsx
+++ b/packages/motif/src/components/Legend/ObjectColours.tsx
@@ -72,9 +72,9 @@ const NodeColour: FC<GraphAttributeColourProps> = ({
         backgroundColor: color.dark,
         borderRadius: '50%',
         cursor: disableClick ? 'initial' : 'pointer',
-        outlineColor: color.normal,
-        outlineWidth: '3px',
-        outlineStyle: 'solid',
+        borderColor: color.normal,
+        borderWidth: '3px',
+        borderStyle: 'solid',
       })}
     />
   );

--- a/packages/motif/src/components/Legend/ObjectColours.tsx
+++ b/packages/motif/src/components/Legend/ObjectColours.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useMemo, MouseEvent } from 'react';
 import { useStyletron } from 'baseui';
 import { Block } from 'baseui/block';
 import { LabelSmall } from 'baseui/typography';
@@ -10,13 +10,29 @@ const ObjectColours: FC<ObjectColourProps> = ({
   kind,
   onClick,
   backgroundColor,
+  disableClick,
 }) => {
   const graphAttribute = useMemo(() => {
+    const isLabelUndefined = label === 'undefined';
+    const isDisable = disableClick || isLabelUndefined;
+
     if (kind === 'node') {
-      return <NodeColour onClick={onClick} backgroundColor={backgroundColor} />;
+      return (
+        <NodeColour
+          onClick={onClick}
+          backgroundColor={backgroundColor}
+          disableClick={isDisable}
+        />
+      );
     }
 
-    return <EdgeColour onClick={onClick} backgroundColor={backgroundColor} />;
+    return (
+      <EdgeColour
+        onClick={onClick}
+        backgroundColor={backgroundColor}
+        disableClick={isDisable}
+      />
+    );
   }, [kind, backgroundColor, onClick]);
 
   return (
@@ -30,16 +46,23 @@ const ObjectColours: FC<ObjectColourProps> = ({
 const NodeColour: FC<GraphAttributeColourProps> = ({
   onClick,
   backgroundColor,
+  disableClick,
 }) => {
   const [css] = useStyletron();
   const color = normalizeColor(backgroundColor);
+
+  const onDivClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (disableClick) return;
+
+    onClick(e);
+  };
 
   return (
     <div
       role='button'
       tabIndex={0}
       aria-label='Node Colour Picker'
-      onClick={onClick}
+      onClick={onDivClick}
       className={css({
         height: '14px',
         width: '14px',
@@ -48,7 +71,7 @@ const NodeColour: FC<GraphAttributeColourProps> = ({
         marginBottom: '4px',
         backgroundColor: color.dark,
         borderRadius: '50%',
-        cursor: 'pointer',
+        cursor: disableClick ? 'initial' : 'pointer',
         outlineColor: color.normal,
         outlineWidth: '3px',
         outlineStyle: 'solid',
@@ -60,14 +83,22 @@ const NodeColour: FC<GraphAttributeColourProps> = ({
 const EdgeColour: FC<GraphAttributeColourProps> = ({
   onClick,
   backgroundColor,
+  disableClick,
 }) => {
   const [css] = useStyletron();
+
+  const onDivClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (disableClick) return;
+
+    onClick(e);
+  };
+
   return (
     <div
       role='button'
       tabIndex={0}
       aria-label='Edge Colour Picker'
-      onClick={onClick}
+      onClick={onDivClick}
       className={css({
         height: '8px',
         width: '24px',
@@ -75,7 +106,7 @@ const EdgeColour: FC<GraphAttributeColourProps> = ({
         marginTop: '4px',
         marginBottom: '4px',
         backgroundColor,
-        cursor: 'pointer',
+        cursor: disableClick ? 'initial' : 'pointer',
       })}
     />
   );

--- a/packages/motif/src/components/Legend/ObjectColours.tsx
+++ b/packages/motif/src/components/Legend/ObjectColours.tsx
@@ -1,0 +1,78 @@
+import React, { FC, useMemo } from 'react';
+import { useStyletron } from 'baseui';
+import { Block } from 'baseui/block';
+import { LabelSmall } from 'baseui/typography';
+import { GraphAttributeColourProps, ObjectColourProps } from './type';
+
+const ObjectColours: FC<ObjectColourProps> = ({
+  kind,
+  onClick,
+  backgroundColor,
+  value,
+}) => {
+  const graphAttribute = useMemo(() => {
+    if (kind === 'node') {
+      return <NodeColour onClick={onClick} backgroundColor={backgroundColor} />;
+    }
+
+    return <EdgeColour onClick={onClick} backgroundColor={backgroundColor} />;
+  }, [kind, backgroundColor, onClick]);
+
+  return (
+    <Block display='flex' alignItems='center' height='24px'>
+      {graphAttribute}
+      <LabelSmall>{value}</LabelSmall>
+    </Block>
+  );
+};
+
+const NodeColour: FC<GraphAttributeColourProps> = ({
+  onClick,
+  backgroundColor,
+}) => {
+  const [css] = useStyletron();
+  return (
+    <div
+      role='button'
+      tabIndex={0}
+      aria-label='Node Colour Picker'
+      onClick={onClick}
+      className={css({
+        height: '16px',
+        width: '16px',
+        marginRight: '6px',
+        marginTop: '4px',
+        marginBottom: '4px',
+        backgroundColor,
+        borderRadius: '50%',
+        cursor: 'pointer',
+      })}
+    />
+  );
+};
+
+const EdgeColour: FC<GraphAttributeColourProps> = ({
+  onClick,
+  backgroundColor,
+}) => {
+  const [css] = useStyletron();
+  return (
+    <div
+      role='button'
+      tabIndex={0}
+      aria-label='Edge Colour Picker'
+      onClick={onClick}
+      className={css({
+        height: '8px',
+        width: '24px',
+        marginRight: '6px',
+        marginTop: '4px',
+        marginBottom: '4px',
+        backgroundColor,
+        cursor: 'pointer',
+      })}
+    />
+  );
+};
+
+export default ObjectColours;

--- a/packages/motif/src/components/Legend/ObjectColours.tsx
+++ b/packages/motif/src/components/Legend/ObjectColours.tsx
@@ -2,13 +2,14 @@ import React, { FC, useMemo } from 'react';
 import { useStyletron } from 'baseui';
 import { Block } from 'baseui/block';
 import { LabelSmall } from 'baseui/typography';
+import { normalizeColor } from '../../utils/style-utils/color-utils';
 import { GraphAttributeColourProps, ObjectColourProps } from './type';
 
 const ObjectColours: FC<ObjectColourProps> = ({
+  label,
   kind,
   onClick,
   backgroundColor,
-  value,
 }) => {
   const graphAttribute = useMemo(() => {
     if (kind === 'node') {
@@ -21,7 +22,7 @@ const ObjectColours: FC<ObjectColourProps> = ({
   return (
     <Block display='flex' alignItems='center' height='24px'>
       {graphAttribute}
-      <LabelSmall>{value}</LabelSmall>
+      <LabelSmall>{label}</LabelSmall>
     </Block>
   );
 };
@@ -31,6 +32,8 @@ const NodeColour: FC<GraphAttributeColourProps> = ({
   backgroundColor,
 }) => {
   const [css] = useStyletron();
+  const color = normalizeColor(backgroundColor);
+
   return (
     <div
       role='button'
@@ -38,14 +41,17 @@ const NodeColour: FC<GraphAttributeColourProps> = ({
       aria-label='Node Colour Picker'
       onClick={onClick}
       className={css({
-        height: '16px',
-        width: '16px',
+        height: '14px',
+        width: '14px',
         marginRight: '6px',
         marginTop: '4px',
         marginBottom: '4px',
-        backgroundColor,
+        backgroundColor: color.dark,
         borderRadius: '50%',
         cursor: 'pointer',
+        outlineColor: color.normal,
+        outlineWidth: '3px',
+        outlineStyle: 'solid',
       })}
     />
   );

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -17,8 +17,10 @@ export type LegendProps = {
 
   // prevent legend popover to change graph attribute colour
   isAllowChangeColor?: boolean;
-};
 
+  // changing the edge/node variable in style panel shall trigger re-render
+  variable?: string;
+};
 export type GraphAttributeColourProps = {
   onClick: MouseEventHandler<HTMLDivElement>;
   backgroundColor: string;

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -1,0 +1,17 @@
+import { MouseEventHandler } from 'react';
+
+export type LegendProps = {
+  data: { [_: string]: string };
+  colorMap: string[];
+  kind: 'node' | 'edge';
+  maxSize?: number;
+  label?: string;
+};
+
+export type GraphAttributeColourProps = {
+  onClick: MouseEventHandler<HTMLDivElement>;
+  backgroundColor: string;
+};
+
+export type ObjectColourProps = GraphAttributeColourProps &
+  Pick<LegendProps, 'kind'> & { value: string };

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -2,11 +2,13 @@ import { MouseEventHandler } from 'react';
 
 export type ColorMaps = [string, string];
 export type LegendProps = {
-  data: { [_: string]: string };
+  data: Record<string, string>;
   colorMap: string[];
   kind: 'node' | 'edge';
   maxSize?: number;
   label?: string;
+
+  // perform attributes colour changes
   onChangeColor?: (target: ColorMaps) => void;
   isAllowChangeColor?: boolean;
 };
@@ -19,3 +21,17 @@ export type GraphAttributeColourProps = {
 
 export type ObjectColourProps = GraphAttributeColourProps &
   Pick<LegendProps, 'kind'> & { label: string };
+
+export type ObjectColourPickerProps = {
+  // selected attribute (node/edge) to modify the color when user clicked on the element.
+  selectedAttr: ColorMaps;
+
+  // function provided to change the node/edge color
+  onChangeColor: (target: ColorMaps) => void;
+
+  // confirm the current colour changes.
+  onComplete: (confirmedColor: ColorMaps) => void;
+
+  // revert the default colour when user decided to discard the changes.
+  onCancel: (defaultColor: ColorMaps) => void;
+};

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -8,11 +8,13 @@ export type LegendProps = {
   maxSize?: number;
   label?: string;
   onChangeColor?: (target: ColorMaps) => void;
+  isAllowChangeColor?: boolean;
 };
 
 export type GraphAttributeColourProps = {
   onClick: MouseEventHandler<HTMLDivElement>;
   backgroundColor: string;
+  disableClick?: boolean;
 };
 
 export type ObjectColourProps = GraphAttributeColourProps &

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -1,11 +1,13 @@
 import { MouseEventHandler } from 'react';
 
+export type ColorMaps = [string, string];
 export type LegendProps = {
   data: { [_: string]: string };
   colorMap: string[];
   kind: 'node' | 'edge';
   maxSize?: number;
   label?: string;
+  onChangeColor?: (target: ColorMaps) => void;
 };
 
 export type GraphAttributeColourProps = {
@@ -14,4 +16,4 @@ export type GraphAttributeColourProps = {
 };
 
 export type ObjectColourProps = GraphAttributeColourProps &
-  Pick<LegendProps, 'kind'> & { value: string };
+  Pick<LegendProps, 'kind'> & { label: string };

--- a/packages/motif/src/components/Legend/type.ts
+++ b/packages/motif/src/components/Legend/type.ts
@@ -5,11 +5,17 @@ export type LegendProps = {
   data: Record<string, string>;
   colorMap: string[];
   kind: 'node' | 'edge';
+
+  // maximum number of graph attribute for display
   maxSize?: number;
+
+  // graph attribute's label text for display
   label?: string;
 
-  // perform attributes colour changes
+  // perform graph attributes colour changes
   onChangeColor?: (target: ColorMaps) => void;
+
+  // prevent legend popover to change graph attribute colour
   isAllowChangeColor?: boolean;
 };
 
@@ -23,13 +29,14 @@ export type ObjectColourProps = GraphAttributeColourProps &
   Pick<LegendProps, 'kind'> & { label: string };
 
 export type ObjectColourPickerProps = {
-  // selected attribute (node/edge) to modify the color when user clicked on the element.
+  // only allow one graph attribute to perform changes in one-time.
+  // selected graph attribute (node/edge) to modify the color when user clicked on the element.
   selectedAttr: ColorMaps;
 
-  // function provided to change the node/edge color
+  // function provided to change the selected node/edge color
   onChangeColor: (target: ColorMaps) => void;
 
-  // confirm the current colour changes.
+  // confirm the graph attribute colour changes.
   onComplete: (confirmedColor: ColorMaps) => void;
 
   // revert the default colour when user decided to discard the changes.

--- a/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsEdgeStyles.tsx
+++ b/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsEdgeStyles.tsx
@@ -128,6 +128,7 @@ const OptionsEdgeStyles = () => {
               label='Colors'
               kind='edge'
               data={edgeStyle.color.mapping}
+              variable={edgeStyle.color.variable}
               colorMap={CATEGORICAL_COLOR}
               maxSize={MAX_LEGEND_SIZE}
               onChangeColor={updateEdgeMappingColor}

--- a/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsEdgeStyles.tsx
+++ b/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsEdgeStyles.tsx
@@ -2,9 +2,9 @@ import React, { useMemo } from 'react';
 import { useStyletron } from 'baseui';
 import { Block } from 'baseui/block';
 import { HeadingXSmall } from 'baseui/typography';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { CATEGORICAL_COLOR } from '../../../constants/colors';
-import { GraphSlices, GraphSelectors } from '../../../redux/graph';
+import { GraphSelectors } from '../../../redux/graph';
 import useEdgeStyle from '../../../redux/graph/hooks/useEdgeStyle';
 import { Card } from '../../../components/ui';
 import {
@@ -29,15 +29,11 @@ const MAX_LEGEND_SIZE = CATEGORICAL_COLOR.length;
 
 const OptionsEdgeStyles = () => {
   const [, theme] = useStyletron();
-  const dispatch = useDispatch();
-  const { edgeStyle } = useEdgeStyle();
+  const { edgeStyle, updateEdgeMappingColor, updateEdgeStyle } = useEdgeStyle();
 
   const { allEdgeFields, numericEdgeFields, edgeLabelFields } = useSelector(
     (state) => GraphSelectors.getGraphFieldsOptions(state),
   );
-
-  const updateEdgeStyle = (data: any) =>
-    dispatch(GraphSlices.changeEdgeStyle(data));
 
   const edgeWidthPropertyValue = useMemo(() => {
     if (edgeStyle.width.id === 'property') {
@@ -134,6 +130,7 @@ const OptionsEdgeStyles = () => {
               data={edgeStyle.color.mapping}
               colorMap={CATEGORICAL_COLOR}
               maxSize={MAX_LEGEND_SIZE}
+              onChangeColor={updateEdgeMappingColor}
             />
           )}
       </Card>

--- a/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
+++ b/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
@@ -4,7 +4,7 @@ import { Block } from 'baseui/block';
 import { HeadingXSmall } from 'baseui/typography';
 import { useDispatch, useSelector } from 'react-redux';
 import { CATEGORICAL_COLOR } from '../../../constants/colors';
-import { GraphSlices, GraphSelectors } from '../../../redux/graph';
+import { GraphSelectors } from '../../../redux/graph';
 import useNodeStyle from '../../../redux/graph/hooks/useNodeStyle';
 import { Card } from '../../../components/ui';
 import {
@@ -26,16 +26,11 @@ const MAX_LEGEND_SIZE = CATEGORICAL_COLOR.length;
 
 const OptionsNodeStyles = () => {
   const [, theme] = useStyletron();
-  const dispatch = useDispatch();
-  const { nodeStyle } = useNodeStyle();
+  const { nodeStyle, updateNodeStyle, updateNodeMappingColor } = useNodeStyle();
 
   const { allNodeFields, nodeLabelFields, numericNodeFields } = useSelector(
     (state) => GraphSelectors.getGraphFieldsOptions(state),
   );
-
-  const updateNodeStyle = (data: any) => {
-    dispatch(GraphSlices.changeNodeStyle(data));
-  };
 
   const nodeSizeFormData = genNestedForm(
     nodeSizeForm,
@@ -121,6 +116,7 @@ const OptionsNodeStyles = () => {
               data={nodeStyle.color.mapping}
               colorMap={CATEGORICAL_COLOR}
               maxSize={MAX_LEGEND_SIZE}
+              onChangeColor={updateNodeMappingColor}
             />
           )}
       </Card>

--- a/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
+++ b/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
@@ -114,6 +114,7 @@ const OptionsNodeStyles = () => {
               label='Colors'
               kind='node'
               data={nodeStyle.color.mapping}
+              variable={nodeStyle.color.variable}
               colorMap={CATEGORICAL_COLOR}
               maxSize={MAX_LEGEND_SIZE}
               onChangeColor={updateNodeMappingColor}

--- a/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
+++ b/packages/motif/src/containers/SidePanel/OptionsPanel/OptionsNodeStyles.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useStyletron } from 'baseui';
 import { Block } from 'baseui/block';
 import { HeadingXSmall } from 'baseui/typography';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { CATEGORICAL_COLOR } from '../../../constants/colors';
 import { GraphSelectors } from '../../../redux/graph';
 import useNodeStyle from '../../../redux/graph/hooks/useNodeStyle';

--- a/packages/motif/src/containers/Toolbar/LegendPopover.tsx
+++ b/packages/motif/src/containers/Toolbar/LegendPopover.tsx
@@ -61,6 +61,7 @@ const LegendPopover = () => {
             data={nodeStyle.color.mapping}
             colorMap={CATEGORICAL_COLOR}
             maxSize={MAX_LEGEND_SIZE}
+            isAllowChangeColor={false}
           />
         </Card>
       )}
@@ -81,6 +82,7 @@ const LegendPopover = () => {
             data={edgeStyle.color.mapping}
             colorMap={CATEGORICAL_COLOR}
             maxSize={MAX_LEGEND_SIZE}
+            isAllowChangeColor={false}
           />
         </Card>
       )}

--- a/packages/motif/src/redux/graph/hooks/useEdgeStyle.tsx
+++ b/packages/motif/src/redux/graph/hooks/useEdgeStyle.tsx
@@ -15,7 +15,19 @@ const useEdgeStyle = () => {
     dispatch(GraphSlices.changeEdgeStyle(dispatchData));
   };
 
-  return { edgeStyle, switchToFixEdgeColor };
+  const updateEdgeStyle = (data: any) =>
+    dispatch(GraphSlices.changeEdgeStyle(data));
+
+  const updateEdgeMappingColor = (target: [string, string]) => {
+    dispatch(GraphSlices.changeEdgeMappingColor(target));
+  };
+
+  return {
+    edgeStyle,
+    switchToFixEdgeColor,
+    updateEdgeMappingColor,
+    updateEdgeStyle,
+  };
 };
 
 export default useEdgeStyle;

--- a/packages/motif/src/redux/graph/hooks/useNodeStyle.tsx
+++ b/packages/motif/src/redux/graph/hooks/useNodeStyle.tsx
@@ -15,7 +15,20 @@ const useNodeStyle = () => {
     dispatch(GraphSlices.changeNodeStyle(dispatchData));
   };
 
-  return { nodeStyle, switchToFixNodeColor };
+  const updateNodeStyle = (data: any) => {
+    dispatch(GraphSlices.changeNodeStyle(data));
+  };
+
+  const updateNodeMappingColor = (target: [string, string]) => {
+    dispatch(GraphSlices.changeNodeMappingColor(target));
+  };
+
+  return {
+    nodeStyle,
+    switchToFixNodeColor,
+    updateNodeStyle,
+    updateNodeMappingColor,
+  };
 };
 
 export default useNodeStyle;

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -19,7 +19,6 @@ import {
   combineProcessedData,
   removeGraphDuplicates,
 } from '../../utils/graph-utils/utils';
-import * as GraphSelectors from './selectors';
 
 /**
  * Perform update on node and edge selections.
@@ -272,6 +271,15 @@ const graph = createSlice({
 
       const { nodeStyle } = state.styleOptions;
       const { mapping = undefined } = nodeStyle.color as T.ColorLegend;
+      if (!mapping) return;
+
+      mapping[attrKey] = colorHex;
+    },
+    changeEdgeMappingColor(state, action: PayloadAction<[string, string]>) {
+      const [attrKey, colorHex] = action.payload;
+
+      const { edgeStyle } = state.styleOptions;
+      const { mapping = undefined } = edgeStyle.color as T.ColorLegend;
       if (!mapping) return;
 
       mapping[attrKey] = colorHex;
@@ -537,6 +545,7 @@ export const {
   updateNodePosition,
   updateFilterOption,
   changeNodeMappingColor,
+  changeEdgeMappingColor,
 } = graph.actions;
 
 export default graph.reducer;

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -293,6 +293,18 @@ const graph = createSlice({
       const { edgeStyle } = state.styleOptions;
       const { mapping = undefined } = edgeStyle.color as T.ColorLegend;
       if (!mapping) return;
+      if (attrKey === 'Others') {
+        const maxSize = 8;
+        const otherEdgeKeys = Object.keys(mapping);
+        const mappingLength = otherEdgeKeys.length;
+
+        const otherKeys = otherEdgeKeys.slice(maxSize + 1, mappingLength);
+        otherKeys.forEach((key) => {
+          mapping[key] = colorHex;
+        });
+
+        return;
+      }
 
       mapping[attrKey] = colorHex;
     },

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -281,8 +281,6 @@ const graph = createSlice({
         otherKeys.forEach((key) => {
           mapping[key] = colorHex;
         });
-
-        return;
       }
 
       mapping[attrKey] = colorHex;
@@ -302,8 +300,6 @@ const graph = createSlice({
         otherKeys.forEach((key) => {
           mapping[key] = colorHex;
         });
-
-        return;
       }
 
       mapping[attrKey] = colorHex;

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -294,6 +294,7 @@ const graph = createSlice({
       if (attrKey === 'Others') {
         const maxSize = 8;
         const otherEdgeKeys = Object.keys(mapping);
+
         const mappingLength = otherEdgeKeys.length;
 
         const otherKeys = otherEdgeKeys.slice(maxSize + 1, mappingLength);

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -272,6 +272,18 @@ const graph = createSlice({
       const { nodeStyle } = state.styleOptions;
       const { mapping = undefined } = nodeStyle.color as T.ColorLegend;
       if (!mapping) return;
+      if (attrKey === 'Others') {
+        const maxSize = 8;
+        const otherNodeKeys = Object.keys(mapping);
+        const mappingLength = otherNodeKeys.length;
+
+        const otherKeys = otherNodeKeys.slice(maxSize + 1, mappingLength);
+        otherKeys.forEach((key) => {
+          mapping[key] = colorHex;
+        });
+
+        return;
+      }
 
       mapping[attrKey] = colorHex;
     },

--- a/packages/motif/src/redux/graph/slice.ts
+++ b/packages/motif/src/redux/graph/slice.ts
@@ -19,6 +19,7 @@ import {
   combineProcessedData,
   removeGraphDuplicates,
 } from '../../utils/graph-utils/utils';
+import * as GraphSelectors from './selectors';
 
 /**
  * Perform update on node and edge selections.
@@ -265,6 +266,15 @@ const graph = createSlice({
           );
         }
       });
+    },
+    changeNodeMappingColor(state, action: PayloadAction<[string, string]>) {
+      const [attrKey, colorHex] = action.payload;
+
+      const { nodeStyle } = state.styleOptions;
+      const { mapping = undefined } = nodeStyle.color as T.ColorLegend;
+      if (!mapping) return;
+
+      mapping[attrKey] = colorHex;
     },
     changeEdgeStyle(
       state,
@@ -526,6 +536,7 @@ export const {
   overwriteEdgeSelection,
   updateNodePosition,
   updateFilterOption,
+  changeNodeMappingColor,
 } = graph.actions;
 
 export default graph.reducer;

--- a/packages/motif/src/redux/graph/tests/constants/positive/json.ts
+++ b/packages/motif/src/redux/graph/tests/constants/positive/json.ts
@@ -495,3 +495,43 @@ export const graphWithFilter = {
     },
   },
 };
+
+export const sampleNodeColourMap = {
+  color: {
+    variable: 'label',
+    id: 'legend',
+    mapping: {
+      'node-0': '#4e79a7',
+      'node-1': '#f28e2c',
+      'node-2': '#e15759',
+      'node-3': '#76b7b2',
+      'node-4': '#59a14f',
+      'node-5': '#edc949',
+      'node-6': '#af7aa1',
+      'node-7': '#ff9da7',
+      'node-8': '#9c755f',
+      'node-9': '#9c755f',
+    },
+  },
+  size: { id: 'fixed', value: 20 },
+  variable: 'label',
+};
+
+export const sampleEdgeColourMap = {
+  color: {
+    variable: 'source',
+    id: 'legend',
+    mapping: {
+      'node-0': '#4e79a7',
+      'node-1': '#f28e2c',
+      'node-2': '#e15759',
+      'node-3': '#76b7b2',
+      'node-4': '#59a14f',
+      'node-5': '#edc949',
+      'node-6': '#af7aa1',
+      'node-7': '#ff9da7',
+      'node-8': '#9c755f',
+      'node-9': '#9c755f',
+    },
+  },
+};

--- a/packages/motif/src/redux/graph/tests/style-colour.test.ts
+++ b/packages/motif/src/redux/graph/tests/style-colour.test.ts
@@ -1,0 +1,105 @@
+import * as GraphSlice from '../slice';
+import graphSlice from '../slice';
+import {
+  sampleNodeColourMap,
+  sampleEdgeColourMap,
+} from './constants/positive/json';
+import { ColorLegend } from '../types';
+
+describe('Style Colour', () => {
+  afterEach(() => {
+    graphSlice(GraphSlice.initialState, GraphSlice.resetState());
+  });
+
+  describe('Style Node with Colour', () => {
+    it('should change specific node colour mapping', () => {
+      const targetNode = 'node-1';
+      const targetColour = '#000000';
+      const inputs = [targetNode, targetColour] as [string, string];
+
+      const nodeStyleState = graphSlice(
+        GraphSlice.initialState,
+        GraphSlice.changeNodeStyle(sampleNodeColourMap),
+      );
+
+      const resultState = graphSlice(
+        nodeStyleState,
+        GraphSlice.changeNodeMappingColor(inputs),
+      );
+
+      const edgeStyleColour = resultState.styleOptions.nodeStyle
+        .color as ColorLegend;
+
+      const expectedEdgeColor = edgeStyleColour.mapping[targetNode];
+      expect(expectedEdgeColor).toBe(targetColour);
+    });
+
+    it('should change "Others" node colour mapping', () => {
+      const targetNode = 'Others';
+      const targetColour = '#000000';
+      const inputs = [targetNode, targetColour] as [string, string];
+
+      const nodeStyleState = graphSlice(
+        GraphSlice.initialState,
+        GraphSlice.changeNodeStyle(sampleNodeColourMap),
+      );
+
+      const resultState = graphSlice(
+        nodeStyleState,
+        GraphSlice.changeNodeMappingColor(inputs),
+      );
+
+      const edgeStyleColour = resultState.styleOptions.nodeStyle
+        .color as ColorLegend;
+
+      const expectedEdgeColor = edgeStyleColour.mapping['node-9'];
+      expect(expectedEdgeColor).toBe(targetColour);
+    });
+  });
+
+  describe('Style Edge with Colour', () => {
+    it('should change specific edge colour mapping', () => {
+      const targetEdge = 'node-1';
+      const targetColour = '#000000';
+      const inputs = [targetEdge, targetColour] as [string, string];
+
+      const edgeStyleState = graphSlice(
+        GraphSlice.initialState,
+        GraphSlice.changeEdgeStyle(sampleEdgeColourMap),
+      );
+
+      const resultState = graphSlice(
+        edgeStyleState,
+        GraphSlice.changeEdgeMappingColor(inputs),
+      );
+
+      const edgeStyleColour = resultState.styleOptions.edgeStyle
+        .color as ColorLegend;
+
+      const expectedEdgeColor = edgeStyleColour.mapping[targetEdge];
+      expect(expectedEdgeColor).toBe(targetColour);
+    });
+
+    it('should change "Others" edge colour mapping', () => {
+      const targetEdge = 'Others';
+      const targetColour = '#000000';
+      const inputs = [targetEdge, targetColour] as [string, string];
+
+      const edgeStyleState = graphSlice(
+        GraphSlice.initialState,
+        GraphSlice.changeEdgeStyle(sampleEdgeColourMap),
+      );
+
+      const resultState = graphSlice(
+        edgeStyleState,
+        GraphSlice.changeEdgeMappingColor(inputs),
+      );
+
+      const edgeStyleColour = resultState.styleOptions.edgeStyle
+        .color as ColorLegend;
+
+      const expectedEdgeColor = edgeStyleColour.mapping['node-9'];
+      expect(expectedEdgeColor).toBe(targetColour);
+    });
+  });
+});

--- a/packages/motif/src/utils/utils.ts
+++ b/packages/motif/src/utils/utils.ts
@@ -61,13 +61,6 @@ export const json2Blob = (json: any): any =>
     type: 'application/json',
   });
 
-export const shortifyLabel = (label: string): string => {
-  if (label.length <= 8) {
-    return label;
-  }
-  return `${label.substring(0, 5)}...`;
-};
-
 export const isBigDataSet = (
   nodeLength: number,
   edgeLength: number,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12461,6 +12461,11 @@ react-clientside-effect@^1.2.5:
   dependencies:
     "@babel/runtime" "^7.12.13"
 
+react-color-palette@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-color-palette/-/react-color-palette-6.2.0.tgz#aa3be88f6953d57502c00f4433692129ffbad3e7"
+  integrity sha512-9rIboaRJNoeF8aCI2f3J8wgMyhl74SnGmZLDjor3bKf0iDBhP2EBv0/jGmm0hrj6OackGCqtWl5ZvM89XUc3sg==
+
 react-dom@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
@@ -14681,11 +14686,6 @@ typescript@^4.2.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 typescript@~4.1.3:
   version "4.1.6"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Features
- Enhancements

## Description

1. Colour picker for user to change the nodes and edges colours.

## Detailed Description

### Style Panel

1. Click on the specific nodes/edges will open a Colour Picker.
2. When release the control of Colour Picker, the target colour will apply and change the selected nodes.
3. Pressing the "Cancel" button will revert back to original colour.
4. Pressing the "Apply" button will applied the current changed colour.

### Legend Popover

1. Should not allow user to change the colour via Legend Popover as it serve as demonstration and summarisation purposes only. 

## Technical Discussion

1. Must store colour code values in HEX code for save and load compatibility.
2. Should not change Node and Edge colour with `undefined` value.
3. Should change all the "Others" node and edges value consistently. 

## Test Plan

1. Jest unit test that covered the branch condition of related slice to ensure accuracy and consistency. 

## Does this PR introduce breaking change?

- No

## Closing Issue

close #213 
